### PR TITLE
Увеличение максимально допустимого кол-ва повторов исполнения до 10К

### DIFF
--- a/src/Dex.Cap/Dex.Cap.Outbox/Dex.Cap.Outbox.csproj
+++ b/src/Dex.Cap/Dex.Cap.Outbox/Dex.Cap.Outbox.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <Nullable>enable</Nullable>
-    <PackageVersion>1.3.19</PackageVersion>
+    <PackageVersion>1.3.20</PackageVersion>
     <PackageTags>outbox business-transaction consistency</PackageTags>
   </PropertyGroup>
 

--- a/src/Dex.Cap/Dex.Cap.Outbox/Options/OutboxOptionsValidator.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox/Options/OutboxOptionsValidator.cs
@@ -12,9 +12,9 @@ namespace Dex.Cap.Outbox.Options
                 return ValidateOptionsResult.Fail("Configuration object is null.");
             }
 
-            if (options.Retries is <= 0 or > 100)
+            if (options.Retries is <= 0 or > 10_000)
             {
-                return ValidateOptionsResult.Fail("Retries should be greater than 0 and less than 100");
+                return ValidateOptionsResult.Fail("Retries should be greater than 0 and less than 10000");
             }
 
             if (options.ProcessorDelay < TimeSpan.FromSeconds(1) || options.ProcessorDelay > TimeSpan.FromHours(1))


### PR DESCRIPTION
При дефолтном значении периода обработки из OutboxHandlerOptions равном 30 секундам 10К повторов обеспечивают попытку исполения в течении почти 3,5 суток вместо 50 минут при максимум 100 повторах.
Вероятность остановить обработку других сообщений такими "долгими" сообщениями есть, в случае когда их накопится более значение MessagesToProcess из OutboxOptions которое по умолчанию равно 100. Но его можно увеличить до 10К