### PR TITLE
Fix DataProtectionFactory bug. Replace Redis client

### DIFF
--- a/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/Dex.SecurityToken.RedisStorage.csproj
+++ b/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/Dex.SecurityToken.RedisStorage.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
-        <PackageVersion>1.0.3</PackageVersion>
+        <PackageVersion>1.0.4</PackageVersion>
         <PackageTags>security token management, redis storage</PackageTags>
     </PropertyGroup>
     
@@ -22,13 +22,19 @@
         <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     </PropertyGroup>
     <!--/Для NuGet-->
-    
-    <ItemGroup>
-      <PackageReference Include="ServiceStack.Interfaces.Core" Version="5.12.0" />
-    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Dex.SecurityTokenProvider\Dex.SecurityTokenProvider.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Update="DistributedCacheTypedClient.cs">
+        <DependentUpon>IDistributedCacheTypedClient.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/DistributedCacheTypedClient.cs
+++ b/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/DistributedCacheTypedClient.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Dex.SecurityToken.RedisStorage
+{
+    public class DistributedCacheTypedClient : IDistributedCacheTypedClient
+    {
+        private readonly IDistributedCache _distributedCache;
+
+        public DistributedCacheTypedClient(IDistributedCache distributedCache)
+        {
+            _distributedCache = distributedCache ?? throw new ArgumentNullException(nameof(distributedCache));
+        }
+
+        public async Task SetAsync<T>(string key, T value, DistributedCacheEntryOptions options, CancellationToken cancellationToken = default)
+        {
+            var utf8Bytes = JsonSerializer.SerializeToUtf8Bytes(value);
+
+            await _distributedCache.SetAsync(key, utf8Bytes, options, cancellationToken);
+        }
+
+        public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+        {
+            var utf8Bytes = await _distributedCache.GetAsync(key, cancellationToken);
+
+            return Deserialize<T>(utf8Bytes);
+        }
+
+        private T? Deserialize<T>(byte[] jsonUtf8Bytes)
+        {
+            var readOnlySpan = new ReadOnlySpan<byte>(jsonUtf8Bytes);
+            var deserializedEntity = JsonSerializer.Deserialize<T>(readOnlySpan);
+            return deserializedEntity;
+        }
+    }
+}

--- a/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/IDistributedCacheTypedClient.cs
+++ b/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/IDistributedCacheTypedClient.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Dex.SecurityToken.RedisStorage
+{
+    public interface IDistributedCacheTypedClient
+    {
+        Task SetAsync<T>(string key, T value, DistributedCacheEntryOptions options, CancellationToken cancellationToken = default);
+
+        Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/MicrosoftDependencyInjectionExtensions.cs
+++ b/src/Dex.SecurityToken/Dex.SecurityToken.RedisStorage/MicrosoftDependencyInjectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Dex.SecurityToken.RedisStorage
+{
+    public static class MicrosoftDependencyInjectionExtensions
+    {
+        /// <summary>
+        /// </summary>
+        /// <param name="services"></param>
+        public static IServiceCollection AddTokenRedisStorageServices(this IServiceCollection services)
+        {
+            services.AddScoped<IDistributedCacheTypedClient, DistributedCacheTypedClient>();
+
+            return services;
+        }
+    }
+}

--- a/src/Dex.SecurityToken/Dex.SecurityTokenProvider/DataProtectionFactory.cs
+++ b/src/Dex.SecurityToken/Dex.SecurityTokenProvider/DataProtectionFactory.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using Dex.SecurityTokenProvider.Interfaces;
-using Dex.SecurityTokenProvider.Options;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Options;
 
 namespace Dex.SecurityTokenProvider
 {
@@ -16,10 +14,9 @@ namespace Dex.SecurityTokenProvider
         private readonly IDataProtectionProvider _dataProtectionProvider;
         private readonly ConcurrentDictionary<string, Lazy<IDataProtector>> _protectors = new();
 
-        public DataProtectionFactory(IOptions<TokenProviderOptions> tokenProviderOptions)
+        public DataProtectionFactory(IDataProtectionProvider dataProtectionProvider)
         {
-            if (tokenProviderOptions.Value == null) throw new ArgumentNullException(nameof(tokenProviderOptions));
-            _dataProtectionProvider = DataProtectionProvider.Create(tokenProviderOptions.Value.ApplicationName);
+            _dataProtectionProvider = dataProtectionProvider ?? throw new ArgumentNullException(nameof(dataProtectionProvider));
         }
 
         public IDataProtector GetDataProtector(string purpose)

--- a/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Dex.SecurityTokenProvider.csproj
+++ b/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Dex.SecurityTokenProvider.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
-        <PackageVersion>1.0.3</PackageVersion>
+        <PackageVersion>1.0.4</PackageVersion>
         <PackageTags>security token management, dataprotection</PackageTags>
     </PropertyGroup>
     

--- a/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Extensions/MicrosoftDependencyInjectionExtensions.cs
+++ b/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Extensions/MicrosoftDependencyInjectionExtensions.cs
@@ -3,7 +3,7 @@ using Dex.SecurityTokenProvider.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Dex.SecurityTokenProvider.Extentions
+namespace Dex.SecurityTokenProvider.Extensions
 {
     public static class MicrosoftDependencyInjectionExtensions
     {
@@ -14,9 +14,9 @@ namespace Dex.SecurityTokenProvider.Extentions
         ///     Must contains section with name "TokenProviderOptions". "ApplicationName" and "ApiResource" is
         ///     required
         /// </param>
-        /// <typeparam name="TokenStorage">implementation if "ITokenInfoStorage"</typeparam>
-        public static IServiceCollection AddSecurityTokenProvider<TokenStorage>(this IServiceCollection services, IConfigurationSection config)
-            where TokenStorage : class, ITokenInfoStorage
+        /// <typeparam name="TTokenStorage">implementation if "ITokenInfoStorage"</typeparam>
+        public static IServiceCollection AddSecurityTokenProvider<TTokenStorage>(this IServiceCollection services, IConfigurationSection config)
+            where TTokenStorage : class, ITokenInfoStorage
         {
             services.AddOptions<TokenProviderOptions>()
                 .Bind(config)
@@ -25,7 +25,7 @@ namespace Dex.SecurityTokenProvider.Extentions
 
             services.AddSingleton<IDataProtectionFactory, DataProtectionFactory>();
             
-            services.AddScoped<ITokenInfoStorage, TokenStorage>();  
+            services.AddScoped<ITokenInfoStorage, TTokenStorage>();  
             services.AddScoped<ITokenProvider, TokenProvider>();
             return services;
         }

--- a/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Interfaces/ITokenInfoStorage.cs
+++ b/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Interfaces/ITokenInfoStorage.cs
@@ -30,8 +30,9 @@ namespace Dex.SecurityTokenProvider.Interfaces
         /// Mark token as used
         /// </summary>
         /// <param name="tokenInfoId">identity key of token</param>
+        /// <param name="cancellationToken"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="TokenInfoNotFoundException"></exception>
-        Task SetActivatedAsync(Guid tokenInfoId);
+        Task SetActivatedAsync(Guid tokenInfoId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Options/TokenProviderOptions.cs
+++ b/src/Dex.SecurityToken/Dex.SecurityTokenProvider/Options/TokenProviderOptions.cs
@@ -6,8 +6,5 @@ namespace Dex.SecurityTokenProvider.Options
     {
         [Required(AllowEmptyStrings = false)] 
         public string ApiResource { get; set; } = null!;
-
-        [Required(AllowEmptyStrings = false)]
-        public string ApplicationName { get; set; } = null!;
     }
 }

--- a/src/Dex.SecurityToken/Tests/Dex.SecurityTokenProviderTests/Dex.SecurityTokenProviderTests.csproj
+++ b/src/Dex.SecurityToken/Tests/Dex.SecurityTokenProviderTests/Dex.SecurityTokenProviderTests.csproj
@@ -29,6 +29,7 @@
 
 
     <ItemGroup>
+      <ProjectReference Include="..\..\Dex.SecurityToken.RedisStorage\Dex.SecurityToken.RedisStorage.csproj" />
       <ProjectReference Include="..\..\Dex.SecurityTokenProvider\Dex.SecurityTokenProvider.csproj" />
     </ItemGroup>
 

--- a/src/Dex.SecurityToken/Tests/Dex.SecurityTokenProviderTests/TestTokenInfoStorage.cs
+++ b/src/Dex.SecurityToken/Tests/Dex.SecurityTokenProviderTests/TestTokenInfoStorage.cs
@@ -29,7 +29,7 @@ namespace Dex.SecurityTokenProviderTests
             return Task.CompletedTask;
         }
 
-        public Task SetActivatedAsync(Guid tokenInfoId)
+        public Task SetActivatedAsync(Guid tokenInfoId, CancellationToken cancellationToken = default)
         {
             if (tokenInfoId == default) throw new ArgumentNullException(nameof(tokenInfoId));
             if (!_tokenInfos.ContainsKey(tokenInfoId)) throw new TokenInfoNotFoundException($"TokenInfoId = {tokenInfoId}");

--- a/src/Dex.SecurityToken/Tests/Dex.SecurityTokenProviderTests/TokenProviderTests.cs
+++ b/src/Dex.SecurityToken/Tests/Dex.SecurityTokenProviderTests/TokenProviderTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dex.SecurityTokenProvider.Exceptions;
-using Dex.SecurityTokenProvider.Extentions;
+using Dex.SecurityTokenProvider.Extensions;
 using Dex.SecurityTokenProvider.Interfaces;
 using Dex.SecurityTokenProvider.Options;
 using Dex.SecurityTokenProviderTests.TestData;
@@ -65,8 +65,9 @@ namespace Dex.SecurityTokenProviderTests
         public void NegativeConcurrencyTest()
         {
             //Arrange
-            var protector1 = DataProtectionProvider.Create("Provider").CreateProtector("Protector");
-            var protector2 = DataProtectionProvider.Create("Provider").CreateProtector("Protector");
+            var dataProtectionProvider = _serviceProvider.GetRequiredService<IDataProtectionProvider>();
+            var protector1 = dataProtectionProvider.CreateProtector("Protector");
+            var protector2 = dataProtectionProvider.CreateProtector("Protector");
 
             var testString = "testString";
             
@@ -108,8 +109,7 @@ namespace Dex.SecurityTokenProviderTests
                 .AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        { $"{nameof(TokenProviderOptions)}:{nameof(TokenProviderOptions.ApiResource)}", "TestAudience" },
-                        { $"{nameof(TokenProviderOptions)}:{nameof(TokenProviderOptions.ApplicationName)}", "ApplicationName" }
+                        { $"{nameof(TokenProviderOptions)}:{nameof(TokenProviderOptions.ApiResource)}", "TestAudience" }
                     }).Build();
 
 
@@ -123,7 +123,8 @@ namespace Dex.SecurityTokenProviderTests
                     o.EnableSensitiveDataLogging();
                 })
                 .AddDataProtection()
-                .PersistKeysToDbContext<DataProtectionKeyContext>();
+                .PersistKeysToDbContext<DataProtectionKeyContext>()
+                .SetApplicationName("TestApp");
 
             services.AddSecurityTokenProvider<TestTokenInfoStorage>(config.GetSection(nameof(TokenProviderOptions)));
             return services.BuildServiceProvider();


### PR DESCRIPTION
Fix DataProtectionFactory bug - inject IDataProtectionProvider instead of DataProtectionProvider.Create. Only DI IDataProtectionProvider use the key store and DataProtection configuration from host application.
Replace ServiceStack Redis client with StackExchange IDistributedCache.