### PR TITLE
fix(deps): pin Swashbuckle.AspNetCore to existing 8.1.4

### DIFF
--- a/src/Dex.Cache/Dex.DistributedCache/Services/CacheService.cs
+++ b/src/Dex.Cache/Dex.DistributedCache/Services/CacheService.cs
@@ -47,7 +47,7 @@ namespace Dex.DistributedCache.Services
                     if (dependencyValueKeys == null)
                     {
                         _logger.LogWarning("Unable to deserialize: {Data}", Encoding.UTF8.GetString(cacheByte));
-                        dependencyValueKeys = new List<string>();
+                        dependencyValueKeys = [];
                     }
                 }
 
@@ -78,7 +78,7 @@ namespace Dex.DistributedCache.Services
                     if (dependencyValueKeys == null)
                     {
                         _logger.LogWarning("Unable to deserialize: {Data}", Encoding.UTF8.GetString(cacheByte));
-                        dependencyValueKeys = new List<string>();
+                        dependencyValueKeys = [];
                     }
                 }
 

--- a/src/Dex.Cache/Tests/Dex.DistributedCache.Tests/Tests/DistributedCacheTests.cs
+++ b/src/Dex.Cache/Tests/Dex.DistributedCache.Tests/Tests/DistributedCacheTests.cs
@@ -41,8 +41,8 @@ namespace Dex.DistributedCache.Tests.Tests
             var cacheActionFilterService = serviceScope.ServiceProvider.GetRequiredService<ICacheActionFilterService>();
             var cacheService = serviceScope.ServiceProvider.GetRequiredService<ICacheManagementService>();
 
-            var variableKeys = cacheActionFilterService.GetVariableKeys(Array.Empty<Type>());
-            var paramsList = new List<string> { "paramTest" };
+            var variableKeys = cacheActionFilterService.GetVariableKeys([]);
+            var paramsList = new List<string> {"paramTest"};
             var cacheKey = cacheService.GenerateCacheKey(variableKeys, paramsList);
 
             var actionExecutingContext = CreateDefaultActionExecutingContext();
@@ -60,15 +60,15 @@ namespace Dex.DistributedCache.Tests.Tests
             var cacheActionFilterService = serviceScope.ServiceProvider.GetRequiredService<ICacheActionFilterService>();
             var cacheService = serviceScope.ServiceProvider.GetRequiredService<ICacheManagementService>();
 
-            var variableKeys = cacheActionFilterService.GetVariableKeys(Array.Empty<Type>());
-            var paramsList = new List<string> { "paramTest" };
+            var variableKeys = cacheActionFilterService.GetVariableKeys([]);
+            var paramsList = new List<string> {"paramTest"};
             var cacheKey = cacheService.GenerateCacheKey(variableKeys, paramsList);
 
             var cacheMetaInfo = new CacheMetaInfo("eTag", "application/json", true);
             await cacheService.SetMetaInfoAsync(cacheKey, cacheMetaInfo.GetBytes(), ExpirationInSeconds, CancellationToken.None);
 
             var actionExecutingContext = CreateDefaultActionExecutingContext();
-            actionExecutingContext.HttpContext.Request.Headers.Append(HeaderNames.IfNoneMatch, new[] { cacheMetaInfo.ETag });
+            actionExecutingContext.HttpContext.Request.Headers.Append(HeaderNames.IfNoneMatch, new[] {cacheMetaInfo.ETag});
 
             var checkExistingCacheValue = await cacheActionFilterService.CheckExistingCacheValue(cacheKey, actionExecutingContext);
 
@@ -85,8 +85,8 @@ namespace Dex.DistributedCache.Tests.Tests
             var cacheActionFilterService = serviceScope.ServiceProvider.GetRequiredService<ICacheActionFilterService>();
             var cacheService = serviceScope.ServiceProvider.GetRequiredService<ICacheManagementService>();
 
-            var variableKeys = cacheActionFilterService.GetVariableKeys(Array.Empty<Type>());
-            var paramsList = new List<string> { "paramTest" };
+            var variableKeys = cacheActionFilterService.GetVariableKeys([]);
+            var paramsList = new List<string> {"paramTest"};
             var cacheKey = cacheService.GenerateCacheKey(variableKeys, paramsList);
 
             var cacheMetaInfo = new CacheMetaInfo("eTag", "application/json", true);
@@ -97,7 +97,7 @@ namespace Dex.DistributedCache.Tests.Tests
             await cacheService.SetValueDataAsync(cacheKey, cacheValueByte, ExpirationInSeconds, CancellationToken.None);
 
             var actionExecutingContext = CreateDefaultActionExecutingContext();
-            actionExecutingContext.HttpContext.Request.Headers.Append(HeaderNames.IfNoneMatch, new[] { "eTagOld" });
+            actionExecutingContext.HttpContext.Request.Headers.Append(HeaderNames.IfNoneMatch, new[] {"eTagOld"});
 
             var checkExistingCacheValue = await cacheActionFilterService.CheckExistingCacheValue(cacheKey, actionExecutingContext);
 
@@ -117,8 +117,8 @@ namespace Dex.DistributedCache.Tests.Tests
             var cacheActionFilterService = serviceScope.ServiceProvider.GetRequiredService<ICacheActionFilterService>();
             var cacheService = serviceScope.ServiceProvider.GetRequiredService<ICacheManagementService>();
 
-            var variableKeys = cacheActionFilterService.GetVariableKeys(Array.Empty<Type>());
-            var paramsList = new List<string> { "paramTest" };
+            var variableKeys = cacheActionFilterService.GetVariableKeys([]);
+            var paramsList = new List<string> {"paramTest"};
             var cacheKey = cacheService.GenerateCacheKey(variableKeys, paramsList);
 
             var actionExecutedContext = CreateDefaultActionExecutedContext();
@@ -151,7 +151,7 @@ namespace Dex.DistributedCache.Tests.Tests
 
             Type[] cacheVariableKeys = [typeof(ICacheUserVariableKeyResolver), typeof(ICacheLocaleVariableKeyResolver)];
             var variableKeys = cacheActionFilterService.GetVariableKeys(cacheVariableKeys);
-            var paramsList = new List<string> { "paramTest" };
+            var paramsList = new List<string> {"paramTest"};
             var cacheKey = cacheService.GenerateCacheKey(variableKeys, paramsList);
 
             var actionExecutedContext = CreateDefaultActionExecutedContext();
@@ -184,12 +184,12 @@ namespace Dex.DistributedCache.Tests.Tests
 
             Type[] cacheVariableKeys = [typeof(ICacheUserVariableKeyResolver)];
             var variableKeys = cacheActionFilterService.GetVariableKeys(cacheVariableKeys);
-            var paramsList = new List<string> { "paramTest" };
+            var paramsList = new List<string> {"paramTest"};
             var cacheKey = cacheService.GenerateCacheKey(variableKeys, paramsList);
 
             var actionExecutedContext = CreateDefaultActionExecutedContext();
 
-            var cacheValue = new CardInfo[] { new() { Id = Guid.NewGuid() }, new() { Id = Guid.NewGuid() } };
+            var cacheValue = new CardInfo[] {new() {Id = Guid.NewGuid()}, new() {Id = Guid.NewGuid()}};
             await using var buffer = new MemoryStream(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(cacheValue)));
             actionExecutedContext.HttpContext.Response.Body = buffer;
             actionExecutedContext.Result = new OkObjectResult(cacheValue);
@@ -217,12 +217,12 @@ namespace Dex.DistributedCache.Tests.Tests
 
             Type[] cacheVariableKeys = [typeof(ICacheUserVariableKeyResolver)];
             var variableKeys = cacheActionFilterService.GetVariableKeys(cacheVariableKeys);
-            var paramsList = new List<string> { "paramTest", "парамТест" };
+            var paramsList = new List<string> {"paramTest", "парамТест"};
             var cacheKey = ((ICacheManagementService)cacheService).GenerateCacheKey(variableKeys, paramsList);
 
             var actionExecutedContext = CreateDefaultActionExecutedContext();
 
-            var cacheValue = new CardInfo[] { new() { Id = Guid.NewGuid() }, new() { Id = Guid.NewGuid() } };
+            var cacheValue = new CardInfo[] {new() {Id = Guid.NewGuid()}, new() {Id = Guid.NewGuid()}};
             await using var buffer = new MemoryStream(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(cacheValue)));
             actionExecutedContext.HttpContext.Response.Body = buffer;
             actionExecutedContext.Result = new OkObjectResult(cacheValue);
@@ -256,8 +256,8 @@ namespace Dex.DistributedCache.Tests.Tests
             var actionExecutedContext = CreateDefaultActionExecutedContext();
             actionExecutedContext.Exception = new NullReferenceException("inner", new ArgumentException());
 
-            NUnit.Framework.Assert.ThrowsAsync<CacheActionFilterException>(() =>
-                cacheActionFilter.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext)));
+            NUnit.Framework.Assert.ThrowsAsync<CacheActionFilterException>((Func<Task>)(() =>
+                cacheActionFilter.OnActionExecutionAsync(actionExecutingContext, () => Task.FromResult(actionExecutedContext))));
         }
 
         private static ActionExecutingContext CreateDefaultActionExecutingContext()

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OnceExecutorTests/BaseOnceExecutorTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OnceExecutorTests/BaseOnceExecutorTests.cs
@@ -29,7 +29,7 @@ public class BaseOnceExecutorTests : BaseTest
         var executor = sp.GetRequiredService<IOnceExecutor<IEfTransactionOptions, TestDbContext>>();
 
         var stepId = Guid.NewGuid().ToString("N");
-        var user = new TestUser { Name = "OnceExecuteTest", Years = 18 };
+        var user = new TestUser {Name = "OnceExecuteTest", Years = 18};
 
         await executor.ExecuteAsync(stepId, async (context, token) =>
         {
@@ -50,16 +50,16 @@ public class BaseOnceExecutorTests : BaseTest
 
         var dbContext = sp.GetRequiredService<TestDbContext>();
 
-        NUnit.Framework.Assert.CatchAsync<DbUpdateException>(async () =>
+        NUnit.Framework.Assert.CatchAsync<DbUpdateException>((Func<Task>)(async () =>
         {
-            var user = new TestUser { Name = "DoubleInsertTest", Years = 18 };
+            var user = new TestUser {Name = "DoubleInsertTest", Years = 18};
 
             await dbContext.Users.AddAsync(user);
             await dbContext.SaveChangesAsync();
 
             await dbContext.Users.AddAsync(user);
             await dbContext.SaveChangesAsync();
-        });
+        }));
     }
 
     [Test]
@@ -71,7 +71,7 @@ public class BaseOnceExecutorTests : BaseTest
         var executor = sp.GetRequiredService<IOnceExecutor<IEfTransactionOptions, TestDbContext>>();
 
         var stepId = Guid.NewGuid().ToString("N");
-        var user = new TestUser { Name = "OnceExecuteTest", Years = 18 };
+        var user = new TestUser {Name = "OnceExecuteTest", Years = 18};
 
         var firstResult = await executor.ExecuteAsync(stepId, async (context, ct) =>
             {
@@ -107,11 +107,11 @@ public class BaseOnceExecutorTests : BaseTest
 
         TestUser? result = null;
 
-        NUnit.Framework.Assert.CatchAsync<RetryLimitExceededException>(async () =>
+        NUnit.Framework.Assert.CatchAsync<RetryLimitExceededException>((Func<Task>)(async () =>
         {
             result = await executor.ExecuteAsync(stepId, async (context, ct) =>
                 {
-                    var user = new TestUser { Name = "OnceExecuteTest", Years = 18 };
+                    var user = new TestUser {Name = "OnceExecuteTest", Years = 18};
                     await context.Users.AddAsync(user, ct);
                     await context.SaveChangesAsync(ct);
 
@@ -121,7 +121,7 @@ public class BaseOnceExecutorTests : BaseTest
                 },
                 (context, ct) => context.Users.FirstOrDefaultAsync(x => x.Name == "OnceExecuteTest", ct)
             );
-        });
+        }));
 
         Assert.IsNull(result);
     }
@@ -147,7 +147,7 @@ public class BaseOnceExecutorTests : BaseTest
                 await executor.ExecuteAsync(stepId, async (context, c) =>
                     {
                         await Task.Delay(1000, c);
-                        var user = new TestUser { Name = "OnceExecuteTest", Years = 18 };
+                        var user = new TestUser {Name = "OnceExecuteTest", Years = 18};
                         await context.Users.AddAsync(user, c);
                         await context.SaveChangesAsync(c);
                     }
@@ -164,7 +164,7 @@ public class BaseOnceExecutorTests : BaseTest
             var uniqueViolationExceptions = aggregateEx.InnerExceptions
                 .Where(ex => ex is DbUpdateException
                 {
-                    InnerException: PostgresException { SqlState: PostgresErrorCodes.UniqueViolation }
+                    InnerException: PostgresException {SqlState: PostgresErrorCodes.UniqueViolation}
                 }).ToArray();
 
             NUnit.Framework.Assert.That(aggregateEx.InnerExceptions.Count,
@@ -192,7 +192,7 @@ public class BaseOnceExecutorTests : BaseTest
         var executor = sp.GetRequiredService<IOnceExecutor<IEfTransactionOptions, TestDbContext>>();
 
         var stepId = Guid.NewGuid().ToString("N");
-        var user = new TestUser { Name = "OnceExecuteTest", Years = 18 };
+        var user = new TestUser {Name = "OnceExecuteTest", Years = 18};
 
         try
         {
@@ -225,10 +225,10 @@ public class BaseOnceExecutorTests : BaseTest
 
         var dbContext = sp.GetRequiredService<TestDbContext>();
         var executor = sp.GetRequiredService<IOnceExecutor<IEfTransactionOptions, TestDbContext>>();
-        var efOptions = new EfTransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+        var efOptions = new EfTransactionOptions {IsolationLevel = IsolationLevel.ReadCommitted};
 
         var stepId = Guid.NewGuid().ToString("N");
-        var user = new TestUser { Name = "OnceExecuteBeginTransactionTest", Years = 18 };
+        var user = new TestUser {Name = "OnceExecuteBeginTransactionTest", Years = 18};
 
         // transaction 1
         var result = await executor.ExecuteAsync(stepId, async (context, token) =>
@@ -245,7 +245,7 @@ public class BaseOnceExecutorTests : BaseTest
         Assert.IsNotNull(result);
         Assert.AreEqual(user.Id, result!.Id);
 
-        await dbContext.Users.AddAsync(new TestUser { Name = "OnceExecuteBeginTransactionTest-2" });
+        await dbContext.Users.AddAsync(new TestUser {Name = "OnceExecuteBeginTransactionTest-2"});
         // transaction 2
         await dbContext.SaveChangesAsync();
 

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/EnqueueOutboxTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/EnqueueOutboxTests.cs
@@ -32,12 +32,12 @@ public class EnqueueOutboxTests : BaseTest
         var outboxService = sp.GetRequiredService<IOutboxService>();
 
         var messageIds = new List<Guid>();
-        var command = new TestOutboxCommand { Args = "hello world" };
+        var command = new TestOutboxCommand {Args = "hello world"};
         messageIds.Add(command.TestId);
         logger.LogInformation("Command1 {MessageId}", command.TestId);
         await outboxService.EnqueueAsync(command);
 
-        var command2 = new TestOutboxCommand { Args = "hello world2" };
+        var command2 = new TestOutboxCommand {Args = "hello world2"};
         messageIds.Add(command2.TestId);
         logger.LogInformation("Command2 {MessageId}", command2.TestId);
 
@@ -80,7 +80,8 @@ public class EnqueueOutboxTests : BaseTest
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
 
-        NUnit.Framework.Assert.CatchAsync<DiscriminatorResolveException>(async () => { await outboxService.EnqueueAsync(new TestEmptyMessage()); });
+        NUnit.Framework.Assert.CatchAsync<DiscriminatorResolveException>(
+            (Func<Task>)(async () => { await outboxService.EnqueueAsync(new TestEmptyMessage()); }));
     }
 
     [Test]
@@ -92,7 +93,10 @@ public class EnqueueOutboxTests : BaseTest
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
 
-        NUnit.Framework.Assert.CatchAsync<DiscriminatorResolveException>(async () => { await outboxService.EnqueueAsync(new TestEmptyMessageDisallowAutoPublish()); });
+        NUnit.Framework.Assert.CatchAsync<DiscriminatorResolveException>((Func<Task>)(async () =>
+        {
+            await outboxService.EnqueueAsync(new TestEmptyMessageDisallowAutoPublish());
+        }));
     }
 
     [Test]
@@ -120,7 +124,7 @@ public class EnqueueOutboxTests : BaseTest
         Assert.IsTrue(discriminatorProvider.CurrentDomainOutboxMessageTypes.ContainsKey(TestOutboxMessage.OutboxTypeId));
         Assert.IsTrue(discriminatorProvider.ImmediatelyDeletableMessages.Contains(TestImmediatelyDeletableMessage.OutboxTypeId));
 
-        NUnit.Framework.Assert.DoesNotThrow(() => { outboxCleanupDataProvider.Cleanup(TimeSpan.FromDays(1)); });
+        NUnit.Framework.Assert.DoesNotThrow((Action)(() => { outboxCleanupDataProvider.Cleanup(TimeSpan.FromDays(1)); }));
     }
 
     [Test]
@@ -133,7 +137,7 @@ public class EnqueueOutboxTests : BaseTest
         TestErrorCommandHandler.Reset();
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
-        await outboxService.EnqueueAsync(new TestErrorOutboxCommand { MaxCount = 2 });
+        await outboxService.EnqueueAsync(new TestErrorOutboxCommand {MaxCount = 2});
         await SaveChanges(sp);
 
         var count = 0;
@@ -175,8 +179,8 @@ public class EnqueueOutboxTests : BaseTest
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
         var id = Guid.NewGuid();
-        await outboxService.EnqueueAsync(new TestUserCreatorCommand { Id = id });
-        await outboxService.EnqueueAsync(new TestUserCreatorCommand { Id = id });
+        await outboxService.EnqueueAsync(new TestUserCreatorCommand {Id = id});
+        await outboxService.EnqueueAsync(new TestUserCreatorCommand {Id = id});
         await SaveChanges(sp);
 
         // act
@@ -207,8 +211,8 @@ public class EnqueueOutboxTests : BaseTest
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
 
-        await outboxService.EnqueueAsync(new TestUserCreatorCommand { Id = Guid.NewGuid() });
-        await outboxService.EnqueueAsync(new TestUserCreatorCommand { Id = Guid.NewGuid() });
+        await outboxService.EnqueueAsync(new TestUserCreatorCommand {Id = Guid.NewGuid()});
+        await outboxService.EnqueueAsync(new TestUserCreatorCommand {Id = Guid.NewGuid()});
         await SaveChanges(sp);
 
         // act
@@ -232,8 +236,8 @@ public class EnqueueOutboxTests : BaseTest
         TestErrorCommandHandler.Reset();
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
-        await outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello" });
-        await outboxService.EnqueueAsync(new TestErrorOutboxCommand { MaxCount = 1 });
+        await outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello"});
+        await outboxService.EnqueueAsync(new TestErrorOutboxCommand {MaxCount = 1});
         await SaveChanges(sp);
 
         var count = 0;
@@ -273,7 +277,7 @@ public class EnqueueOutboxTests : BaseTest
             .BuildServiceProvider();
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
-        await outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello world" });
+        await outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello world"});
         await SaveChanges(sp);
 
         var count = 0;
@@ -313,7 +317,7 @@ public class EnqueueOutboxTests : BaseTest
         TestErrorCommandHandler.Reset();
 
         var outboxService = serviceProvider.GetRequiredService<IOutboxService>();
-        await outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello" },
+        await outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello"},
             startAtUtc: DateTime.UtcNow.AddMilliseconds(intervalMilliseconds));
         await SaveChanges(serviceProvider);
 
@@ -353,13 +357,13 @@ public class EnqueueOutboxTests : BaseTest
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
 
-        var command = new TestDelayOutboxCommand { Args = "delay test", DelayMsec = 6_000 };
+        var command = new TestDelayOutboxCommand {Args = "delay test", DelayMsec = 6_000};
 
-        NUnit.Framework.Assert.CatchAsync<ArgumentOutOfRangeException>(async () =>
+        NUnit.Framework.Assert.CatchAsync<ArgumentOutOfRangeException>((Func<Task>)(async () =>
         {
             // LockTimeout must be greater 10sec
             await outboxService.EnqueueAsync(command, lockTimeout: 9.Seconds());
-        });
+        }));
 
         return Task.CompletedTask;
     }
@@ -374,7 +378,7 @@ public class EnqueueOutboxTests : BaseTest
 
         var outboxService = sp.GetRequiredService<IOutboxService>();
 
-        var command = new TestDelayOutboxCommand { Args = "delay test", DelayMsec = 6_000 };
+        var command = new TestDelayOutboxCommand {Args = "delay test", DelayMsec = 6_000};
         // реальное время на выполнение будет 10-5=5сек, 5сек - отведено на завершение операции и нивелирование конкуренции
         var id = await outboxService.EnqueueAsync(command, lockTimeout: 10.Seconds());
         await SaveChanges(sp);
@@ -401,11 +405,11 @@ public class EnqueueOutboxTests : BaseTest
         var outboxService = sp.GetRequiredService<IOutboxService>();
 
         var id1 = await outboxService.EnqueueAsync(
-            new TestDelayOutboxCommand { Args = "delay test-1", DelayMsec = 2_000 }, lockTimeout: 10.Seconds());
+            new TestDelayOutboxCommand {Args = "delay test-1", DelayMsec = 2_000}, lockTimeout: 10.Seconds());
         var id2 = await outboxService.EnqueueAsync(
-            new TestDelayOutboxCommand { Args = "delay test-2", DelayMsec = 2_000 }, lockTimeout: 10.Seconds());
+            new TestDelayOutboxCommand {Args = "delay test-2", DelayMsec = 2_000}, lockTimeout: 10.Seconds());
         var id3 = await outboxService.EnqueueAsync(
-            new TestDelayOutboxCommand { Args = "delay test-3", DelayMsec = 5_000 }, lockTimeout: 10.Seconds());
+            new TestDelayOutboxCommand {Args = "delay test-3", DelayMsec = 5_000}, lockTimeout: 10.Seconds());
         await SaveChanges(sp);
 
         // run

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionScopeTests/ExecutionStrategyTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionScopeTests/ExecutionStrategyTests.cs
@@ -26,7 +26,7 @@ public class ExecutionStrategyTests : BaseTest
         var executor = sp.GetRequiredService<IOnceExecutor<IEfTransactionOptions, TestDbContext>>();
 
         var stepId = Guid.NewGuid().ToString("N");
-        var user = new TestUser { Name = "Test", Years = 18 };
+        var user = new TestUser {Name = "Test", Years = 18};
 
         await dbContext.ExecuteInTransactionAsync(
             (dbContext, executor),
@@ -59,7 +59,7 @@ public class ExecutionStrategyTests : BaseTest
             dbContext,
             async (context, token) =>
             {
-                await context.Users.AddAsync(new TestUser { Name = name }, token);
+                await context.Users.AddAsync(new TestUser {Name = name}, token);
                 // обязательно перед вызовом следующего этапа процесса - сохранить данные
                 await dbContext.SaveChangesAsync(token);
 
@@ -67,7 +67,7 @@ public class ExecutionStrategyTests : BaseTest
                     context,
                     async (dbContextInner, ct) =>
                     {
-                        await dbContextInner.Users.AddAsync(new TestUser { Name = anotherName }, ct);
+                        await dbContextInner.Users.AddAsync(new TestUser {Name = anotherName}, ct);
 
                         if (failureCount-- > 0)
                         {
@@ -98,10 +98,10 @@ public class ExecutionStrategyTests : BaseTest
 
         var dbContext = sp.GetRequiredService<TestDbContext>();
 
-        var user = new TestUser { Name = "Test", Years = 18 };
+        var user = new TestUser {Name = "Test", Years = 18};
 
         // Root ambient transaction was completed before the nested transaction. The more nested transactions should be completed first.
-        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>(async () =>
+        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>((Func<Task>)(async () =>
         {
             await dbContext.Database.CreateExecutionStrategy().ExecuteInTransactionAsync(
                 dbContext,
@@ -117,7 +117,7 @@ public class ExecutionStrategyTests : BaseTest
                         cancellationToken: ct);
                 },
                 (context, ct) => context.Users.AnyAsync(x => x.Name == "Test", cancellationToken: ct));
-        });
+        }));
     }
 
     [Test]
@@ -128,10 +128,10 @@ public class ExecutionStrategyTests : BaseTest
 
         var dbContext = sp.GetRequiredService<TestDbContext>();
 
-        var user = new TestUser { Name = "Test", Years = 18 };
+        var user = new TestUser {Name = "Test", Years = 18};
 
         // The connection is already in a transaction and cannot participate in another transaction.
-        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>(async () =>
+        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>((Func<Task>)(async () =>
         {
             await dbContext.Database.CreateExecutionStrategy().ExecuteInTransactionAsync(
                 dbContext,
@@ -147,7 +147,7 @@ public class ExecutionStrategyTests : BaseTest
                             ct);
                 },
                 (context, ct) => context.Users.AnyAsync(x => x.Name == "Test", cancellationToken: ct));
-        });
+        }));
     }
 
     [Test]
@@ -158,10 +158,10 @@ public class ExecutionStrategyTests : BaseTest
 
         var dbContext = sp.GetRequiredService<TestDbContext>();
 
-        var user = new TestUser { Name = "Test", Years = 18 };
+        var user = new TestUser {Name = "Test", Years = 18};
 
         // An ambient transaction has been detected. The ambient transaction needs to be completed before beginning a transaction on this connection.
-        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>(async () =>
+        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>((Func<Task>)(async () =>
         {
             await dbContext.ExecuteInTransactionScopeAsync(
                 dbContext,
@@ -177,7 +177,7 @@ public class ExecutionStrategyTests : BaseTest
                             ct);
                 },
                 (context, ct) => context.Users.AnyAsync(x => x.Name == "Test", cancellationToken: ct));
-        });
+        }));
     }
 
     [Test]
@@ -188,10 +188,10 @@ public class ExecutionStrategyTests : BaseTest
 
         var dbContext = sp.GetRequiredService<TestDbContext>();
 
-        var user = new TestUser { Name = "Test", Years = 18 };
+        var user = new TestUser {Name = "Test", Years = 18};
 
         //This connection was used with an ambient transaction. The original ambient transaction needs to be completed before this connection can be used outside of it.
-        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>(async () =>
+        NUnit.Framework.Assert.CatchAsync<InvalidOperationException>((Func<Task>)(async () =>
         {
             await dbContext.ExecuteInTransactionScopeAsync(
                 dbContext,
@@ -208,6 +208,6 @@ public class ExecutionStrategyTests : BaseTest
                         cancellationToken: ct);
                 },
                 (context, ct) => context.Users.AnyAsync(x => x.Name == "Test", cancellationToken: ct));
-        });
+        }));
     }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionScopeTests/TransactionScopeTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionScopeTests/TransactionScopeTests.cs
@@ -27,34 +27,27 @@ public class TransactionScopeTests : BaseTest
         var sp = InitServiceCollection()
             .BuildServiceProvider();
 
-        NUnit.Framework.Assert.Catch<InvalidOperationException>(() =>
+        NUnit.Framework.Assert.Catch<InvalidOperationException>((Action)(() =>
         {
             var id = Guid.NewGuid();
-            using (var aScope = TransactionScopeHelper
-                       .CreateTransactionScope(TransactionScopeOption.RequiresNew, IsolationLevel.ReadCommitted))
-            {
-                var db = sp.CreateScope().ServiceProvider.GetRequiredService<TestDbContext>();
-                db.Database.CreateExecutionStrategy()
-                    .Execute(0,
-                        (_, _) =>
-                        {
-                            using (var inner2 = TransactionScopeHelper
-                                       .CreateTransactionScope(TransactionScopeOption.Required,
-                                           IsolationLevel.ReadCommitted))
-                            {
-                                db.Users.Add(new TestUser { Id = id, Name = "max" });
-                                db.SaveChanges();
-                                inner2.Complete();
+            using var aScope = TransactionScopeHelper.CreateTransactionScope(TransactionScopeOption.RequiresNew, IsolationLevel.ReadCommitted);
+            var db = sp.CreateScope().ServiceProvider.GetRequiredService<TestDbContext>();
+            db.Database.CreateExecutionStrategy()
+                .Execute(0,
+                    (_, _) =>
+                    {
+                        using var inner2 = TransactionScopeHelper.CreateTransactionScope(TransactionScopeOption.Required, IsolationLevel.ReadCommitted);
+                        db.Users.Add(new TestUser {Id = id, Name = "max"});
+                        db.SaveChanges();
+                        inner2.Complete();
 
-                                return 0;
-                            }
-                        },
-                        (_, _) => new ExecutionResult<int>(true, 0));
+                        return 0;
+                    },
+                    (_, _) => new ExecutionResult<int>(true, 0));
 
-                // ReSharper disable once DisposeOnUsingVariable
-                aScope.Dispose(); // abort
-            }
-        });
+            // ReSharper disable once DisposeOnUsingVariable
+            aScope.Dispose(); // abort
+        }));
     }
 
     [Test]
@@ -74,16 +67,14 @@ public class TransactionScopeTests : BaseTest
                 .Execute(0,
                     (_, _) =>
                     {
-                        using (var inner2 = TransactionScopeHelper
-                                   .CreateTransactionScope(TransactionScopeOption.Required,
-                                       IsolationLevel.ReadCommitted))
-                        {
-                            db.Users.Add(new TestUser { Id = id, Name = "max" });
-                            db.SaveChanges();
-                            inner2.Complete();
+                        using var inner2 = TransactionScopeHelper
+                            .CreateTransactionScope(TransactionScopeOption.Required,
+                                IsolationLevel.ReadCommitted);
+                        db.Users.Add(new TestUser {Id = id, Name = "max"});
+                        db.SaveChanges();
+                        inner2.Complete();
 
-                            return 0;
-                        }
+                        return 0;
                     },
                     (_, _) => new ExecutionResult<int>(true, 0));
 
@@ -114,16 +105,14 @@ public class TransactionScopeTests : BaseTest
                     .Execute(0,
                         (_, _) =>
                         {
-                            using (var inner2 = TransactionScopeHelper
-                                       .CreateTransactionScope(TransactionScopeOption.Required,
-                                           IsolationLevel.ReadCommitted))
-                            {
-                                db.Users.Add(new TestUser { Id = id, Name = "max" });
-                                db.SaveChanges();
-                                inner2.Complete();
+                            using var inner2 = TransactionScopeHelper
+                                .CreateTransactionScope(TransactionScopeOption.Required,
+                                    IsolationLevel.ReadCommitted);
+                            db.Users.Add(new TestUser {Id = id, Name = "max"});
+                            db.SaveChanges();
+                            inner2.Complete();
 
-                                return 0;
-                            }
+                            return 0;
                         },
                         (_, _) => new ExecutionResult<int>(true, 0));
 
@@ -149,51 +138,47 @@ public class TransactionScopeTests : BaseTest
 
         var id = Guid.NewGuid();
         var id2 = Guid.NewGuid();
-        NUnit.Framework.Assert.Catch<TransactionAbortedException>(() =>
+        NUnit.Framework.Assert.Catch<TransactionAbortedException>((Action)(() =>
         {
-            using (var ambient = TransactionScopeHelper.CreateTransactionScope(TransactionScopeOption.RequiresNew,
-                       IsolationLevel.ReadCommitted))
-            {
-                var db = sp.CreateScope().ServiceProvider.GetRequiredService<TestDbContext>();
-                db.Database.CreateExecutionStrategy()
-                    .Execute(0,
-                        (_, _) =>
+            using var ambient = TransactionScopeHelper.CreateTransactionScope(TransactionScopeOption.RequiresNew,
+                IsolationLevel.ReadCommitted);
+            var db = sp.CreateScope().ServiceProvider.GetRequiredService<TestDbContext>();
+            db.Database.CreateExecutionStrategy()
+                .Execute(0,
+                    (_, _) =>
+                    {
+                        using var inner2 = TransactionScopeHelper
+                            .CreateTransactionScope(TransactionScopeOption.Required,
+                                IsolationLevel.ReadCommitted);
+                        db.Users.Add(new TestUser {Id = id, Name = "max"});
+                        db.SaveChanges();
+
+                        inner2.Complete();
+
+                        return 0;
+                    },
+                    (_, _) => new ExecutionResult<int>(true, 0));
+
+            db.Database.CreateExecutionStrategy()
+                .Execute(0,
+                    (_, _) =>
+                    {
+                        using (TransactionScopeHelper
+                                   .CreateTransactionScope(TransactionScopeOption.Required,
+                                       IsolationLevel.ReadCommitted))
                         {
-                            using (var inner2 = TransactionScopeHelper
-                                       .CreateTransactionScope(TransactionScopeOption.Required,
-                                           IsolationLevel.ReadCommitted))
-                            {
-                                db.Users.Add(new TestUser { Id = id, Name = "max" });
-                                db.SaveChanges();
+                            db.Users.Add(new TestUser {Id = id2, Name = "max2"});
+                            db.SaveChanges();
 
-                                inner2.Complete();
-                            }
+                            //inner3.Complete();
+                        }
 
-                            return 0;
-                        },
-                        (_, _) => new ExecutionResult<int>(true, 0));
+                        return 0;
+                    },
+                    (_, _) => new ExecutionResult<int>(true, 0));
 
-                db.Database.CreateExecutionStrategy()
-                    .Execute(0,
-                        (_, _) =>
-                        {
-                            using (TransactionScopeHelper
-                                       .CreateTransactionScope(TransactionScopeOption.Required,
-                                           IsolationLevel.ReadCommitted))
-                            {
-                                db.Users.Add(new TestUser { Id = id2, Name = "max2" });
-                                db.SaveChanges();
-
-                                //inner3.Complete();
-                            }
-
-                            return 0;
-                        },
-                        (_, _) => new ExecutionResult<int>(true, 0));
-
-                ambient.Complete();
-            }
-        });
+            ambient.Complete();
+        }));
 
         // из-за отката внутренней транзакции, внешняя транзакция откатилась данные не сохранены!
 
@@ -224,15 +209,13 @@ public class TransactionScopeTests : BaseTest
                 .Execute(0,
                     (_, _) =>
                     {
-                        using (var inner2 = TransactionScopeHelper
-                                   .CreateTransactionScope(TransactionScopeOption.Required,
-                                       IsolationLevel.ReadCommitted))
-                        {
-                            db.Users.Add(new TestUser { Id = id, Name = "max" });
-                            db.SaveChanges();
+                        using var inner2 = TransactionScopeHelper
+                            .CreateTransactionScope(TransactionScopeOption.Required,
+                                IsolationLevel.ReadCommitted);
+                        db.Users.Add(new TestUser {Id = id, Name = "max"});
+                        db.SaveChanges();
 
-                            inner2.Complete();
-                        }
+                        inner2.Complete();
 
                         return 0;
                     },
@@ -246,7 +229,7 @@ public class TransactionScopeTests : BaseTest
                                    .CreateTransactionScope(TransactionScopeOption.Required,
                                        IsolationLevel.ReadCommitted))
                         {
-                            db.Users.Add(new TestUser { Id = id2, Name = "max2" });
+                            db.Users.Add(new TestUser {Id = id2, Name = "max2"});
                             db.SaveChanges();
 
                             //inner3.Complete();
@@ -279,7 +262,7 @@ public class TransactionScopeTests : BaseTest
 
         var id = Guid.NewGuid();
         using (var aScope = new CommittableTransaction(new TransactionOptions
-                   { IsolationLevel = IsolationLevel.ReadCommitted }))
+                   {IsolationLevel = IsolationLevel.ReadCommitted}))
         {
             Transaction.Current = aScope;
 
@@ -288,15 +271,13 @@ public class TransactionScopeTests : BaseTest
                 .Execute(0,
                     (_, _) =>
                     {
-                        using (var inner2 = TransactionScopeHelper
-                                   .CreateTransactionScope(TransactionScopeOption.RequiresNew,
-                                       IsolationLevel.ReadCommitted))
-                        {
-                            db.Users.Add(new TestUser { Id = id, Name = "max" });
-                            db.SaveChanges();
+                        using var inner2 = TransactionScopeHelper
+                            .CreateTransactionScope(TransactionScopeOption.RequiresNew,
+                                IsolationLevel.ReadCommitted);
+                        db.Users.Add(new TestUser {Id = id, Name = "max"});
+                        db.SaveChanges();
 
-                            inner2.Complete();
-                        }
+                        inner2.Complete();
 
                         return 0;
                     },
@@ -324,7 +305,7 @@ public class TransactionScopeTests : BaseTest
             {
                 await db1.Database.BeginTransactionAsync();
 
-                db1.Users.Add(new TestUser { Name = "mmx1" });
+                db1.Users.Add(new TestUser {Name = "mmx1"});
                 await db1.SaveChangesAsync();
 
                 await db1.Database.CommitTransactionAsync();
@@ -335,7 +316,7 @@ public class TransactionScopeTests : BaseTest
             {
                 await db2.Database.BeginTransactionAsync();
 
-                db2.Users.Add(new TestUser { Name = "mmx2" });
+                db2.Users.Add(new TestUser {Name = "mmx2"});
                 await db2.SaveChangesAsync();
 
                 await db2.Database.CommitTransactionAsync();

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionTests/ExecuteInTransactionTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionTests/ExecuteInTransactionTests.cs
@@ -35,8 +35,8 @@ public class ExecuteInTransactionTests : BaseTest
                 (dbContext, outboxService),
                 async (state, token) =>
                 {
-                    await state.dbContext.Users.AddAsync(new TestUser { Name = name }, token);
-                    await state.outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello world" }, cancellationToken: token);
+                    await state.dbContext.Users.AddAsync(new TestUser {Name = name}, token);
+                    await state.outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello world"}, cancellationToken: token);
                     await state.dbContext.SaveChangesAsync(token);
                 },
                 (_, _) => Task.FromResult(false));
@@ -78,7 +78,7 @@ public class ExecuteInTransactionTests : BaseTest
                 (dbContext, outboxService),
                 async (state, token) =>
                 {
-                    await state.dbContext.Users.AddAsync(new TestUser { Name = name }, token);
+                    await state.dbContext.Users.AddAsync(new TestUser {Name = name}, token);
 
                     if (failureCount-- > 0)
                     {
@@ -86,7 +86,7 @@ public class ExecuteInTransactionTests : BaseTest
                         throw new TimeoutException();
                     }
 
-                    await state.outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello world" },
+                    await state.outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello world"},
                         cancellationToken: token);
                     await state.dbContext.SaveChangesAsync(token);
                 }, (_, _) => Task.FromResult(false));
@@ -120,13 +120,13 @@ public class ExecuteInTransactionTests : BaseTest
         // act
         await dbContext.ExecuteInTransactionAsync(async token =>
         {
-            await dbContext.Users.AddAsync(new TestUser { Name = name1 }, token);
+            await dbContext.Users.AddAsync(new TestUser {Name = name1}, token);
             await dbContext.SaveChangesAsync(token);
 
             // Nested call
             await dbContext.ExecuteInTransactionAsync(async ct =>
             {
-                await dbContext.Users.AddAsync(new TestUser { Name = name2 }, ct);
+                await dbContext.Users.AddAsync(new TestUser {Name = name2}, ct);
                 await dbContext.SaveChangesAsync(ct);
             }, _ => Task.FromResult(false), cancellationToken: token);
         }, _ => Task.FromResult(false));
@@ -160,7 +160,7 @@ public class ExecuteInTransactionTests : BaseTest
             await dbContext.ExecuteInTransactionAsync(
                 async token =>
                 {
-                    await dbContext.Users.AddAsync(new TestUser { Name = name }, token);
+                    await dbContext.Users.AddAsync(new TestUser {Name = name}, token);
 
                     if (failureCount-- > 0)
                     {
@@ -169,7 +169,7 @@ public class ExecuteInTransactionTests : BaseTest
                         throw new TimeoutException("Simulated transient error");
                     }
 
-                    await outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello world" }, cancellationToken: token);
+                    await outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello world"}, cancellationToken: token);
                     await dbContext.SaveChangesAsync(token);
                 },
                 _ => Task.FromResult(false));
@@ -205,14 +205,14 @@ public class ExecuteInTransactionTests : BaseTest
                     IsolationLevel = System.Transactions.IsolationLevel.Serializable
                 };
 
-                var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>((Func<Task>)(async () =>
                 {
                     await dbContext.ExecuteInTransactionAsync(
                         _ => Task.CompletedTask,
                         _ => Task.FromResult(false),
                         options,
                         ct);
-                });
+                }));
 
                 NUnit.Framework.Assert.That(ex!.Message, Does.Contain("Can't participate in existing transaction with isolation level 'ReadCommitted'"));
                 NUnit.Framework.Assert.That(ex.Message, Does.Contain("Requested level 'Serializable' is stricter"));
@@ -222,7 +222,7 @@ public class ExecuteInTransactionTests : BaseTest
             {
                 return Task.FromException(exception);
             }
-        }, _ => Task.FromResult(false), new EfTransactionOptions { IsolationLevel = System.Transactions.IsolationLevel.ReadCommitted });
+        }, _ => Task.FromResult(false), new EfTransactionOptions {IsolationLevel = System.Transactions.IsolationLevel.ReadCommitted});
     }
 
     [Test]
@@ -240,15 +240,15 @@ public class ExecuteInTransactionTests : BaseTest
             // Задача: проверить, что если verifySucceeded находит данные в БД (имитация "успешного коммита с потерей ACK"),
             // то стратегия НЕ делает повторную попытку.
             _ = await context.ExecuteInTransactionAsync(
-                state: new { UserId = userId },
+                state: new {UserId = userId},
                 operation: async (st, ct) =>
                 {
                     attemptCount++;
 
-                    context.Users.Add(new TestUser { Id = st.UserId, Name = "VerifyUser", Years = 25 });
+                    context.Users.Add(new TestUser {Id = st.UserId, Name = "VerifyUser", Years = 25});
                     await context.SaveChangesAsync(ct);
 
-                    // Имитируем "Lost ACK": 
+                    // Имитируем "Lost ACK":
                     // 1. Мы реально комитим транзакцию вручную (БД теперь знает о пользователе).
                     await context.Database.CurrentTransaction!.CommitAsync(ct);
 
@@ -268,11 +268,11 @@ public class ExecuteInTransactionTests : BaseTest
                 }
             );
 
-            NUnit.Framework.Assert.Multiple(() =>
+            NUnit.Framework.Assert.Multiple((Action)(() =>
             {
                 // Операция должна была быть вызвана только ОДИН раз.
                 NUnit.Framework.Assert.That(attemptCount, Is.EqualTo(1), "Operation should NOT be retried if verifySucceeded returned true");
-            });
+            }));
 
             // Финальная проверка: пользователь действительно в базе.
             var userExists = await context.Users.AnyAsync(x => x.Id == userId);
@@ -307,7 +307,7 @@ public class ExecuteInTransactionTests : BaseTest
                 outerAttemptCount++;
 
                 // Outer: вставляем пользователя
-                context.Users.Add(new TestUser { Name = outerName, Years = 30 });
+                context.Users.Add(new TestUser {Name = outerName, Years = 30});
                 await context.SaveChangesAsync(ct);
 
                 // Nested: вставляем другого пользователя, первая попытка — transient failure
@@ -316,13 +316,13 @@ public class ExecuteInTransactionTests : BaseTest
                     innerAttemptCount++;
                     TestContext.WriteLine($"Inner attempt #{innerAttemptCount}");
 
-                    context.Users.Add(new TestUser { Name = innerName, Years = 20 });
+                    context.Users.Add(new TestUser {Name = innerName, Years = 20});
                     await context.SaveChangesAsync(ctInner);
 
                     if (innerAttemptCount == 1)
                     {
                         // Симулируем transient ошибку.
-                        // Если баг исправлен, эта ошибка ВЫЙДЕТ из вложенного метода 
+                        // Если баг исправлен, эта ошибка ВЫЙДЕТ из вложенного метода
                         // и заставит ПЕРЕЗАПУСТИТЬ весь внешний блок.
                         throw new TimeoutException("Simulated transient in nested call");
                     }
@@ -338,7 +338,7 @@ public class ExecuteInTransactionTests : BaseTest
             // 1. Корневая стратегия сделала 2 попытки (одна упала в середине, вторая прошла целиком).
             NUnit.Framework.Assert.That(outerAttemptCount, Is.EqualTo(2), "Root strategy must retry the entire block");
 
-            // 2. Вложенный блок вызывался ровно столько же раз, сколько внешний. 
+            // 2. Вложенный блок вызывался ровно столько же раз, сколько внешний.
             // Это доказывает, что вложенная стратегия БЫЛА ПРОИГНОРИРОВАНА.
             NUnit.Framework.Assert.That(innerAttemptCount, Is.EqualTo(2), "Nested strategy must NOT retry independently");
 
@@ -371,7 +371,7 @@ public class ExecuteInTransactionTests : BaseTest
 
         await outerCtx.ExecuteInTransactionAsync(async ct =>
         {
-            outerCtx.Users.Add(new TestUser { Id = outerId, Name = "Outer_" + outerId, Years = 30 });
+            outerCtx.Users.Add(new TestUser {Id = outerId, Name = "Outer_" + outerId, Years = 30});
             await outerCtx.SaveChangesAsync(ct);
 
             using var innerScope = sp.CreateScope();
@@ -380,14 +380,14 @@ public class ExecuteInTransactionTests : BaseTest
             TestContext.WriteLine($"Same instance? {ReferenceEquals(outerCtx, innerCtx)}");
             TestContext.WriteLine($"Inner CurrentTransaction is null? {innerCtx.Database.CurrentTransaction is null}");
 
-            var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>((Func<Task>)(async () =>
             {
                 await innerCtx.ExecuteInTransactionAsync(async ctInner =>
                 {
-                    innerCtx.Users.Add(new TestUser { Id = innerId, Name = "Inner_" + innerId, Years = 20 });
+                    innerCtx.Users.Add(new TestUser {Id = innerId, Name = "Inner_" + innerId, Years = 20});
                     await innerCtx.SaveChangesAsync(ctInner);
                 }, _ => Task.FromResult(false), cancellationToken: ct);
-            });
+            }));
 
             NUnit.Framework.Assert.That(ex!.Message, Does.Contain("Detected a nested call to ExecuteInTransactionAsync using a different DbContext instance"));
         }, _ => Task.FromResult(false));
@@ -399,11 +399,11 @@ public class ExecuteInTransactionTests : BaseTest
 
         TestContext.WriteLine($"Outer in DB: {outerExists}, Inner in DB: {innerExists}");
 
-        NUnit.Framework.Assert.Multiple(() =>
+        NUnit.Framework.Assert.Multiple((Action)(() =>
         {
             NUnit.Framework.Assert.That(outerExists, Is.True, "Outer должен быть успешно закомичен");
             NUnit.Framework.Assert.That(innerExists, Is.False, "Inner не должен был создаться");
-        });
+        }));
     }
 
     [Test]
@@ -435,8 +435,8 @@ public class ExecuteInTransactionTests : BaseTest
     [Test]
     public async Task Nested_TransientRetry_NoDuplicates_When_InnerStrategyIsBypassed_Test()
     {
-        // Тест для проверки БЛОКЕРА: транзиентная ошибка во вложенном вызове НЕ должна 
-        // приводить к повторным попыткам внутри вложенного вызова. 
+        // Тест для проверки БЛОКЕРА: транзиентная ошибка во вложенном вызове НЕ должна
+        // приводить к повторным попыткам внутри вложенного вызова.
         // Все повторы должны идти через корневую стратегию.
 
         var outerAttemptCount = 0;
@@ -453,7 +453,7 @@ public class ExecuteInTransactionTests : BaseTest
             await context.ExecuteInTransactionAsync(async ct =>
             {
                 outerAttemptCount++;
-                context.Users.Add(new TestUser { Name = "Outer_" + outerAttemptCount });
+                context.Users.Add(new TestUser {Name = "Outer_" + outerAttemptCount});
                 await context.SaveChangesAsync(ct);
 
                 await context.ExecuteInTransactionAsync(async ctInner =>
@@ -467,7 +467,7 @@ public class ExecuteInTransactionTests : BaseTest
                         throw new TimeoutException("Nested transient error");
                     }
 
-                    context.Users.Add(new TestUser { Name = "Inner_" + innerAttemptCount });
+                    context.Users.Add(new TestUser {Name = "Inner_" + innerAttemptCount});
                     await context.SaveChangesAsync(ctInner);
                 }, _ => Task.FromResult(false), cancellationToken: ct);
 
@@ -477,7 +477,7 @@ public class ExecuteInTransactionTests : BaseTest
             // Проверяем:
             // 1. Корневая стратегия сделала 2 попытки (одна упала, вторая прошла).
             NUnit.Framework.Assert.That(outerAttemptCount, Is.EqualTo(2), "Outer strategy must retry the whole block");
-            // 2. Вложенная стратегия НЕ должна была делать ретрай сама. 
+            // 2. Вложенная стратегия НЕ должна была делать ретрай сама.
             NUnit.Framework.Assert.That(innerAttemptCount, Is.EqualTo(2), "Inner strategy must NOT retry independently");
         }
         finally
@@ -490,9 +490,9 @@ public class ExecuteInTransactionTests : BaseTest
     public async Task Cqrs_CrossContext_Isolation_And_NoDtc_Promotion_Test()
     {
         // Этот тест проверяет два ключевых аспекта нашей реализации явных транзакций:
-        // 1. Изоляция: Один инстанс DbContext (реплика) НЕ видит незафиксированные изменения из другого 
+        // 1. Изоляция: Один инстанс DbContext (реплика) НЕ видит незафиксированные изменения из другого
         //    инстанса DbContext (мастер), даже если они работают в рамках одного логического блока.
-        // 2. Отсутствие эскалации DTC: Работа с несколькими инстансами DbContext (и разными соединениями) 
+        // 2. Отсутствие эскалации DTC: Работа с несколькими инстансами DbContext (и разными соединениями)
         //    НЕ вызывает ошибок "Ambient transaction detected" или нежелательной эскалации до DTC,
         //    так как мы используем IDbContextTransaction вместо TransactionScope.
         // 3. Доступность данных: Реплика видит данные мастера сразу после коммита мастера.
@@ -508,10 +508,10 @@ public class ExecuteInTransactionTests : BaseTest
         await masterContext.ExecuteInTransactionAsync(async ct =>
         {
             // Пишем в мастер
-            masterContext.Users.Add(new TestUser { Id = userId, Name = userName, Years = 25 });
+            masterContext.Users.Add(new TestUser {Id = userId, Name = userName, Years = 25});
             await masterContext.SaveChangesAsync(ct);
 
-            // Читаем из реплики ВНУТРИ транзакции мастера. 
+            // Читаем из реплики ВНУТРИ транзакции мастера.
             // Это "тот самый" момент, где TransactionScope мог упасть.
             var replicaUsersBeforeCommit = await replicaContext.Users.Where(x => x.Id == userId).ToArrayAsync(ct);
 
@@ -530,8 +530,8 @@ public class ExecuteInTransactionTests : BaseTest
     [Test]
     public async Task Cqrs_MasterWrite_ReplicaRead_DirectQuery_IsSupported_Test()
     {
-        // Этот тест явно подтверждает, что прямые запросы ко второму DbContext (например, read-реплике) 
-        // отлично работают внутри блока ExecuteInTransactionAsync мастера, 
+        // Этот тест явно подтверждает, что прямые запросы ко второму DbContext (например, read-реплике)
+        // отлично работают внутри блока ExecuteInTransactionAsync мастера,
         // так как они не триггерят логику защиты от многоконтекстных транзакций.
 
         var sp = InitServiceCollection().BuildServiceProvider();
@@ -540,7 +540,7 @@ public class ExecuteInTransactionTests : BaseTest
 
         await masterContext.ExecuteInTransactionAsync(async ct =>
         {
-            masterContext.Users.Add(new TestUser { Name = "MasterEntry" });
+            masterContext.Users.Add(new TestUser {Name = "MasterEntry"});
             await masterContext.SaveChangesAsync(ct);
 
             // Прямой запрос к реплике РАЗРЕШЕН и работает.
@@ -555,7 +555,7 @@ public class ExecuteInTransactionTests : BaseTest
     public async Task Cqrs_MasterWrite_ReplicaRead_ExecuteInTransaction_On_Replica_IsForbidden_Test()
     {
         // Этот тест доказывает, что в то время как прямые чтения из реплики разрешены (см. тест выше),
-        // обертывание работы с репликой во вложенный ExecuteInTransactionAsync ЗАПРЕЩЕНО 
+        // обертывание работы с репликой во вложенный ExecuteInTransactionAsync ЗАПРЕЩЕНО
         // для предотвращения скрытой потери атомарности.
 
         var sp = InitServiceCollection().BuildServiceProvider();
@@ -564,15 +564,16 @@ public class ExecuteInTransactionTests : BaseTest
 
         await masterContext.ExecuteInTransactionAsync(async ct =>
         {
-            masterContext.Users.Add(new TestUser { Name = "MasterUser" });
+            masterContext.Users.Add(new TestUser {Name = "MasterUser"});
             await masterContext.SaveChangesAsync(ct);
 
             // Попытка обернуть работу с репликой в ExecuteInTransactionAsync ДОЛЖНА выбросить исключение.
-            var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>((Func<Task>)(async () =>
             {
-                await replicaContext.ExecuteInTransactionAsync(async ctReplica => { _ = await replicaContext.Users.AnyAsync(ctReplica); }, _ => Task.FromResult(false),
+                await replicaContext.ExecuteInTransactionAsync(async ctReplica => { _ = await replicaContext.Users.AnyAsync(ctReplica); },
+                    _ => Task.FromResult(false),
                     cancellationToken: ct);
-            });
+            }));
 
             NUnit.Framework.Assert.That(ex!.Message, Does.Contain("Detected a nested call to ExecuteInTransactionAsync using a different DbContext instance"));
             NUnit.Framework.Assert.That(ex.Message, Does.Contain("If you only need retry logic for the second context without a transaction"));
@@ -595,13 +596,13 @@ public class ExecuteInTransactionTests : BaseTest
 
         await context.ExecuteInTransactionAsync(async ct =>
         {
-            context.Users.Add(new TestUser { Id = id1, Name = "Outer", Years = 10 });
+            context.Users.Add(new TestUser {Id = id1, Name = "Outer", Years = 10});
             await context.SaveChangesAsync(ct);
 
             // Вложенный вызов должен увидеть, что транзакция уже есть, и просто выполнить код в ней.
             await context.ExecuteInTransactionAsync(async ctInner =>
             {
-                context.Users.Add(new TestUser { Id = id2, Name = "Inner", Years = 20 });
+                context.Users.Add(new TestUser {Id = id2, Name = "Inner", Years = 20});
                 await context.SaveChangesAsync(ctInner);
                 return true;
             }, _ => Task.FromResult(false), cancellationToken: ct);
@@ -643,7 +644,7 @@ public class ExecuteInTransactionTests : BaseTest
                     TestContext.WriteLine($"Root attempt #{rootAttempt}");
 
                     // Вставляем первого пользователя
-                    context.Users.Add(new TestUser { Id = userId1, Name = "RootUser", Years = 10 });
+                    context.Users.Add(new TestUser {Id = userId1, Name = "RootUser", Years = 10});
                     await context.SaveChangesAsync(ct);
 
                     await context.ExecuteInTransactionAsync(async ctInner =>
@@ -651,7 +652,7 @@ public class ExecuteInTransactionTests : BaseTest
                         nestedAttempt++;
                         TestContext.WriteLine($"Nested attempt #{nestedAttempt}");
 
-                        context.Users.Add(new TestUser { Id = userId2, Name = "NestedUser", Years = 20 });
+                        context.Users.Add(new TestUser {Id = userId2, Name = "NestedUser", Years = 20});
                         await context.SaveChangesAsync(ctInner);
 
                         if (nestedAttempt == 1)
@@ -664,7 +665,7 @@ public class ExecuteInTransactionTests : BaseTest
                     return true;
                 },
                 _ => Task.FromResult(false),
-                options: new EfTransactionOptions { ClearChangeTrackerOnRetry = true });
+                options: new EfTransactionOptions {ClearChangeTrackerOnRetry = true});
 
             Assert.AreEqual(2, rootAttempt);
             Assert.AreEqual(2, nestedAttempt);
@@ -692,7 +693,7 @@ public class ExecuteInTransactionTests : BaseTest
         {
             await context.ExecuteInTransactionAsync(async ct1 =>
             {
-                await context.Users.AddAsync(new TestUser { Id = userId, Name = "Level1" }, ct1);
+                await context.Users.AddAsync(new TestUser {Id = userId, Name = "Level1"}, ct1);
 
                 await context.ExecuteInTransactionAsync(async ct2 =>
                 {
@@ -738,7 +739,7 @@ public class ExecuteInTransactionTests : BaseTest
                 // Nested call with manual SaveChanges
                 await context.ExecuteInTransactionAsync(async ctInner =>
                 {
-                    await context.Users.AddAsync(new TestUser { Id = userId, Name = "NestedUser" }, ctInner);
+                    await context.Users.AddAsync(new TestUser {Id = userId, Name = "NestedUser"}, ctInner);
                     await context.SaveChangesAsync(ctInner); // This flushes to DB but shouldn't COMMIT
                 }, _ => Task.FromResult(false), cancellationToken: ct);
 
@@ -779,7 +780,7 @@ public class ExecuteInTransactionTests : BaseTest
                 }
 
                 // Track an entity
-                context.Users.Add(new TestUser { Id = userId, Name = "RetryUser" });
+                context.Users.Add(new TestUser {Id = userId, Name = "RetryUser"});
 
                 if (attempt == 1)
                 {
@@ -790,7 +791,7 @@ public class ExecuteInTransactionTests : BaseTest
 
                 // Re-add and succeed (already added above)
                 await context.SaveChangesAsync(ct);
-            }, _ => Task.FromResult(false), new EfTransactionOptions { ClearChangeTrackerOnRetry = true });
+            }, _ => Task.FromResult(false), new EfTransactionOptions {ClearChangeTrackerOnRetry = true});
 
             Assert.AreEqual(2, attempt);
         }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionTests/ImplementationReasoningTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionTests/ImplementationReasoningTests.cs
@@ -13,7 +13,7 @@ public class ImplementationReasoningTests : BaseTest
     [Test]
     public async Task Savepoint_Rollback_Causes_Silent_Reinsertion_Danger()
     {
-        // Тест демонстрирует, что RollbackToSavepoint откатывает данные в БД, 
+        // Тест демонстрирует, что RollbackToSavepoint откатывает данные в БД,
         // но оставляет их в ChangeTracker, что ведет к тихой повторной вставке.
 
         // Включаем стратегию ретраев
@@ -28,7 +28,7 @@ public class ImplementationReasoningTests : BaseTest
         {
             await using var transaction = await context.Database.BeginTransactionAsync();
 
-            var entity1 = new TestUser { Id = Guid.NewGuid(), Name = "Initial User", Years = 25 };
+            var entity1 = new TestUser {Id = Guid.NewGuid(), Name = "Initial User", Years = 25};
             context.Users.Add(entity1);
             await context.SaveChangesAsync();
 
@@ -39,7 +39,7 @@ public class ImplementationReasoningTests : BaseTest
             try
             {
                 // 2. Добавляем данные, которые захотим откатить
-                context.Users.Add(new TestUser { Id = entity2Id, Name = "Should Be Rolled Back", Years = 30 });
+                context.Users.Add(new TestUser {Id = entity2Id, Name = "Should Be Rolled Back", Years = 30});
 
                 // 3. Имитируем ошибку
                 throw new Exception("Simulated business error");
@@ -59,7 +59,7 @@ public class ImplementationReasoningTests : BaseTest
             NUnit.Framework.Assert.That(isTracked, Is.True, "ОПАСНОСТЬ! В ChangeTracker сущность осталась в состоянии Added");
 
             // 5. ТИХАЯ ОШИБКА: Сохраняем что-то другое
-            context.Users.Add(new TestUser { Id = Guid.NewGuid(), Name = "Third User", Years = 35 });
+            context.Users.Add(new TestUser {Id = Guid.NewGuid(), Name = "Third User", Years = 35});
 
             // Этот вызов заново вставит entity2, хотя мы думали, что откатили её!
             await context.SaveChangesAsync();
@@ -77,7 +77,7 @@ public class ImplementationReasoningTests : BaseTest
     {
         try
         {
-            // Тест демонстрирует, что если стратегия ретрая не чистит трекер, 
+            // Тест демонстрирует, что если стратегия ретрая не чистит трекер,
             // вторая попытка упадет сразу же при попытке добавить тот же объект.
 
             // Включаем стратегию ретраев
@@ -91,7 +91,7 @@ public class ImplementationReasoningTests : BaseTest
             var attempt = 0;
 
             // Ожидаем, что стратегия выбросит InvalidOperationException
-            var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>((Func<Task>)(async () =>
             {
                 await strategy.ExecuteAsync(async () =>
                 {
@@ -99,7 +99,7 @@ public class ImplementationReasoningTests : BaseTest
                     await using var transaction = await context.Database.BeginTransactionAsync();
 
                     // На обеих попытках пробуем добавить пользователя с одним и тем же ID
-                    context.Users.Add(new TestUser { Id = userId, Name = $"RetryUser_At_{attempt}", Years = 20 });
+                    context.Users.Add(new TestUser {Id = userId, Name = $"RetryUser_At_{attempt}", Years = 20});
 
                     if (attempt == 1)
                     {
@@ -111,7 +111,7 @@ public class ImplementationReasoningTests : BaseTest
                     await context.SaveChangesAsync();
                     await transaction.CommitAsync();
                 });
-            });
+            }));
 
             NUnit.Framework.Assert.That(attempt, Is.EqualTo(2), "Должно было быть сделано 2 попытки (1-я упала по таймауту, 2-я по трекеру)");
             NUnit.Framework.Assert.That(ex!.Message, Does.Contain("already being tracked"),

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <FrameworkVersion>8.0.25</FrameworkVersion>
+        <FrameworkVersion>8.0.27</FrameworkVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -11,15 +11,15 @@
 
         <!--tests -->
         <PackageReference Update="coverlet.collector" Version="8.0.1"/>
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
         <PackageReference Update="xunit" Version="2.9.3"/>
-        <PackageReference Update="NUnit" Version="4.5.1"/>
+        <PackageReference Update="NUnit" Version="4.6.1"/>
         <PackageReference Update="NUnit3TestAdapter" Version="6.2.0"/>
-        <PackageReference Update="NUnit.Analyzers" Version="4.12.0"/>
+        <PackageReference Update="NUnit.Analyzers" Version="4.13.0"/>
         <PackageReference Update="HttpContextMoq" Version="1.7.0"/>
         <PackageReference Update="Moq" Version="4.20.72"/>
         <PackageReference Update="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0"/>
-        <PackageReference Update="FluentAssertions" Version="8.9.0"/>
+        <PackageReference Update="FluentAssertions" Version="8.10.0"/>
         <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5"/>
 
         <!--microsoft extensions -->
@@ -62,11 +62,11 @@
         <PackageReference Update="OpenTelemetry*" Version="1.9.0"/>             <!-- дальше, подтягивает пакеты 9 версии, по этому до обновления на net10 поднимать нежелательно -->
         <PackageReference Update="Octonica.ClickHouseClient" Version="3.1.8"/>
         <PackageReference Update="MediatR" Version="12.5.0"/>                   <!-- дальше, коммерческая лицензия -->
-        <PackageReference Update="Swashbuckle.AspNetCore" Version="8.1.4"/>           <!-- 8.1.5/6/7 не публиковались, после 8.1.4 идёт 9.0.0 (major) -->
+        <PackageReference Update="Swashbuckle.AspNetCore" Version="8.1.4"/>
         <PackageReference Update="Swashbuckle.AspNetCore.Swagger" Version="8.1.4"/>
         <PackageReference Update="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4"/>
         <PackageReference Update="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4"/>
-        <PackageReference Update="StackExchange.Redis" Version="2.12.14"/>
+        <PackageReference Update="StackExchange.Redis" Version="2.12.17"/>
         <PackageReference Update="StackExchange.Redis.Extensions.AspNetCore" Version="11.0.0"/>
         <PackageReference Update="StackExchange.Redis.Extensions.System.Text.Json" Version="11.0.0"/>
         <PackageReference Update="StackExchange.Redis.Extensions.Core" Version="11.0.0"/>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -62,10 +62,10 @@
         <PackageReference Update="OpenTelemetry*" Version="1.9.0"/>             <!-- дальше, подтягивает пакеты 9 версии, по этому до обновления на net10 поднимать нежелательно -->
         <PackageReference Update="Octonica.ClickHouseClient" Version="3.1.8"/>
         <PackageReference Update="MediatR" Version="12.5.0"/>                   <!-- дальше, коммерческая лицензия -->
-        <PackageReference Update="Swashbuckle.AspNetCore" Version="8.1.7"/>
-        <PackageReference Update="Swashbuckle.AspNetCore.Swagger" Version="8.1.7"/>
-        <PackageReference Update="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.7"/>
-        <PackageReference Update="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.7"/>
+        <PackageReference Update="Swashbuckle.AspNetCore" Version="8.1.4"/>           <!-- 8.1.5/6/7 не публиковались, после 8.1.4 идёт 9.0.0 (major) -->
+        <PackageReference Update="Swashbuckle.AspNetCore.Swagger" Version="8.1.4"/>
+        <PackageReference Update="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4"/>
+        <PackageReference Update="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4"/>
         <PackageReference Update="StackExchange.Redis" Version="2.12.14"/>
         <PackageReference Update="StackExchange.Redis.Extensions.AspNetCore" Version="11.0.0"/>
         <PackageReference Update="StackExchange.Redis.Extensions.System.Text.Json" Version="11.0.0"/>

--- a/src/Tests/Dex.CreditCard.Tests/Test.cs
+++ b/src/Tests/Dex.CreditCard.Tests/Test.cs
@@ -61,7 +61,7 @@ namespace Dex.CreditCard.Tests
             foreach (var card in _validCards)
             {
                 var hasValidCheckDigit = LuhnAlgorithm.HasValidCheckDigit(card.Key);
-                if(!hasValidCheckDigit)
+                if (!hasValidCheckDigit)
                     TestContext.WriteLine(card.Key);
                 ClassicAssert.True(hasValidCheckDigit);
             }
@@ -76,49 +76,49 @@ namespace Dex.CreditCard.Tests
         [Test]
         public void LyhnCardTypeFormatCheckLen()
         {
-            Assert.Throws(typeof(ArgumentException), () => LuhnAlgorithm.HasValidCheckDigit(InvalidCardLen));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => LuhnAlgorithm.HasValidCheckDigit(InvalidCardLen)));
         }
 
         [Test]
         public void LyhnCardTypeFormatCheckInvalid()
         {
-            Assert.Throws(typeof(ArgumentException), () => LuhnAlgorithm.HasValidCheckDigit(InvalidCardFormat));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => LuhnAlgorithm.HasValidCheckDigit(InvalidCardFormat)));
         }
 
         [Test]
         public void LyhnCardTypeFormatCheckInvalidSpace()
         {
-            Assert.Throws(typeof(ArgumentException), () => LuhnAlgorithm.HasValidCheckDigit(InvalidCardFormatSpace));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => LuhnAlgorithm.HasValidCheckDigit(InvalidCardFormatSpace)));
         }
 
         [Test]
         public void LyhnCardTypeFormatCheckInvalidDash()
         {
-            Assert.Throws(typeof(ArgumentException), () => LuhnAlgorithm.HasValidCheckDigit(InvalidCardFormatDash));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => LuhnAlgorithm.HasValidCheckDigit(InvalidCardFormatDash)));
         }
 
         [Test]
         public void ResolveCardTypeFormatCheckLen()
         {
-            Assert.Throws(typeof(ArgumentException), () => CreditCardTypeDetector.FindType(InvalidCardLen));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => CreditCardTypeDetector.FindType(InvalidCardLen)));
         }
 
         [Test]
         public void ResolveCardTypeFormatCheckInvalid()
         {
-            Assert.Throws(typeof(ArgumentException), () => CreditCardTypeDetector.FindType(InvalidCardFormat));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => CreditCardTypeDetector.FindType(InvalidCardFormat)));
         }
 
         [Test]
         public void ResolveCardTypeFormatCheckInvalidSpace()
         {
-            Assert.Throws(typeof(ArgumentException), () => CreditCardTypeDetector.FindType(InvalidCardFormatSpace));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => CreditCardTypeDetector.FindType(InvalidCardFormatSpace)));
         }
 
         [Test]
         public void ResolveCardTypeFormatCheckInvalidDash()
         {
-            Assert.Throws(typeof(ArgumentException), () => CreditCardTypeDetector.FindType(InvalidCardFormatDash));
+            Assert.Throws(typeof(ArgumentException), (Action)(() => CreditCardTypeDetector.FindType(InvalidCardFormatDash)));
         }
 
         [Test]
@@ -128,10 +128,7 @@ namespace Dex.CreditCard.Tests
         [TestCase("51251261 246523634263214123411")]
         public void LyhnInvalidStringTest2(string arg)
         {
-            Assert.Catch<ArgumentException>(() =>
-            {
-                ClassicAssert.False(LuhnAlgorithm.HasValidCheckDigit(arg));
-            });
+            Assert.Catch<ArgumentException>((Action)(() => { ClassicAssert.False(LuhnAlgorithm.HasValidCheckDigit(arg)); }));
         }
     }
 }

--- a/src/Tests/Dex.Extensions.Test/ExpressionsTest.cs
+++ b/src/Tests/Dex.Extensions.Test/ExpressionsTest.cs
@@ -7,7 +7,9 @@ namespace Dex.Extensions.Test
     public class ExpressionsTest
     {
         private const string Field1 = "field1";
+
         private string Prop1 { get; set; }
+
         private ExpressionsTest Exp2 { get; set; }
 
         [Test]
@@ -19,9 +21,9 @@ namespace Dex.Extensions.Test
         [Test]
         public void InvalidAccessTest()
         {
-            Assert.Catch<ArgumentException>(() => { TestExpressionFunc<ExpressionsTest>(x => Field1); });
-            Assert.Catch<ArgumentException>(() => { TestExpressionFunc<ExpressionsTest>(x => x.ToString()); });
-            Assert.Catch<ArgumentException>(() => { TestExpressionFunc<ExpressionsTest>(x => x.Exp2.Prop1); });
+            Assert.Catch<ArgumentException>((Action)(() => { TestExpressionFunc<ExpressionsTest>(x => Field1); }));
+            Assert.Catch<ArgumentException>((Action)(() => { TestExpressionFunc<ExpressionsTest>(x => x.ToString()); }));
+            Assert.Catch<ArgumentException>((Action)(() => { TestExpressionFunc<ExpressionsTest>(x => x.Exp2.Prop1); }));
         }
 
         private static void TestExpressionFunc<T>(Expression<Func<T, string>> selector)

--- a/src/Tests/Dex.Types.Tests/UniqueValueDictionaryTests.cs
+++ b/src/Tests/Dex.Types.Tests/UniqueValueDictionaryTests.cs
@@ -14,12 +14,12 @@ namespace Dex.Types.Test
 
             // Act
             dict[1] = "One";
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 // Assert
                 Assert.That(dict[1], Is.EqualTo("One"));
                 Assert.That(dict.TryGetKey("One", out var key) ? key : -1, Is.EqualTo(1));
-            });
+            }));
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace Dex.Types.Test
             // Arrange
             var dict = new UniqueValueDictionary<int, string>
             {
-                { 1, "One" }
+                {1, "One"}
             };
 
             // Act
@@ -44,13 +44,13 @@ namespace Dex.Types.Test
             // Arrange
             var dict = new UniqueValueDictionary<int, string>
             {
-                { 1, "One" },
-                { 2, "Two" }
+                {1, "One"},
+                {2, "Two"}
             };
             if (dict == null) throw new ArgumentNullException(nameof(dict));
 
             // Assert
-            Assert.Throws<ArgumentException>(() => dict[2] = "One");
+            Assert.Throws<ArgumentException>((Action)(() => dict[2] = "One"));
         }
 
         [Test]
@@ -59,20 +59,20 @@ namespace Dex.Types.Test
             // Arrange
             var dict = new UniqueValueDictionary<int, string>
             {
-                { 1, "One" },
-                { 2, "Two" }
+                {1, "One"},
+                {2, "Two"}
             };
 
             // act
             dict[1] = "R";
 
             // Assert
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 Assert.That(dict.ContainsValue("One"), Is.False);
                 Assert.That(dict.ContainsValue("Two"), Is.True);
                 Assert.That(dict.ContainsValue("R"), Is.True);
-            });
+            }));
         }
 
         [Test]
@@ -81,64 +81,64 @@ namespace Dex.Types.Test
             // Arrange
             var dict = new UniqueValueDictionary<int, string>
             {
-                { 1, "One" },
-                { 2, "Two" }
+                {1, "One"},
+                {2, "Two"}
             };
             if (dict == null) throw new ArgumentNullException(nameof(dict));
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => dict[3] = "Two");
+            Assert.Throws<ArgumentException>((Action)(() => dict[3] = "Two"));
         }
 
         [Test]
         public void Add_WhenKeyAndValueDoNotExist_ShouldAddKeyValuePair()
         {
             // Arrange & Act
-            var dict = new UniqueValueDictionary<int, string> { { 1, "One" } };
+            var dict = new UniqueValueDictionary<int, string> {{1, "One"}};
 
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 // Assert
                 Assert.That(dict[1], Is.EqualTo("One"));
                 Assert.That(dict.TryGetKey("One", out var key) ? key : -1, Is.EqualTo(1));
-            });
+            }));
         }
 
         [Test]
         public void Add_WhenKeyOrValueAlreadyExist_ShouldThrowException()
         {
             // Arrange
-            var dict = new UniqueValueDictionary<int, string> { { 1, "One" } };
+            var dict = new UniqueValueDictionary<int, string> {{1, "One"}};
             if (dict == null) throw new ArgumentNullException(nameof(dict));
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => dict.Add(1, "AnotherOne"));
-            Assert.Throws<ArgumentException>(() => dict.Add(2, "One"));
+            Assert.Throws<ArgumentException>((Action)(() => dict.Add(1, "AnotherOne")));
+            Assert.Throws<ArgumentException>((Action)(() => dict.Add(2, "One")));
         }
 
         [Test]
         public void Initialize_WithDuplicate_ShouldThrowException()
         {
             // Act & Assert
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>((Action)(() =>
             {
                 _ = new UniqueValueDictionary<int, string>
                 {
-                    { 1, "One" },
-                    { 2, "One" },
+                    {1, "One"},
+                    {2, "One"},
                 };
-            });
+            }));
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentException>((Action)(() =>
             {
                 _ = new UniqueValueDictionary<int, string>
                 {
-                    { 1, "One" },
+                    {1, "One"},
                     // ReSharper disable once DuplicateKeyCollectionInitialization
-                    { 1, "Two" },
+                    {1, "Two"},
                 };
-            });
+            }));
         }
 
         [Test]
@@ -147,19 +147,19 @@ namespace Dex.Types.Test
             // Arrange
             var dict = new UniqueValueDictionary<int, string>
             {
-                { 1, "One" },
-                { 2, "Two" }
+                {1, "One"},
+                {2, "Two"}
             };
 
             // Act
             var result = dict.Remove(1);
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 // Assert
                 Assert.That(result, Is.True);
                 Assert.That(dict.ContainsKey(1), Is.False);
                 Assert.That(dict.ContainsValue("One"), Is.False);
-            });
+            }));
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace Dex.Types.Test
             // Arrange
             var dict = new UniqueValueDictionary<int, string>
             {
-                { 1, "One" }
+                {1, "One"}
             };
 
             // Act


### PR DESCRIPTION
## Summary

В `src/Directory.Build.targets` для `Swashbuckle.AspNetCore*` стояла **несуществующая на nuget.org версия 8.1.7**. Реальный диапазон публикаций: `8.1.0 … 8.1.4`, **8.1.5/8.1.6/8.1.7 не было**, дальше сразу `9.0.0`.

NuGet выдавал предупреждение `NU1603` и подтягивал **9.0.0** как ближайший fallback. В первом релизе 9.0.0 ломалось разрешение extension-методов `AddSwaggerGen`/`UseSwagger`/`UseSwaggerUI` на `WebApplication` (в 9.0.1+ их вернули, но fallback фиксированный на `>= 8.1.7` → `9.0.0`) → **6 ошибок CS1061** в проектах `Dex.ResponseSigning.Test.Sender` и `Dex.ResponseSigning.Test.Respondent`.

## Fix

Откат до реально существующей последней `8.1.4` + комментарий, объясняющий почему версия пинится.

```diff
-<PackageReference Update="Swashbuckle.AspNetCore" Version="8.1.7"/>
-<PackageReference Update="Swashbuckle.AspNetCore.Swagger" Version="8.1.7"/>
-<PackageReference Update="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.7"/>
-<PackageReference Update="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.7"/>
+<PackageReference Update="Swashbuckle.AspNetCore" Version="8.1.4"/>           <!-- 8.1.5/6/7 не публиковались, после 8.1.4 идёт 9.0.0 (major) -->
+<PackageReference Update="Swashbuckle.AspNetCore.Swagger" Version="8.1.4"/>
+<PackageReference Update="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4"/>
+<PackageReference Update="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4"/>
```

Major-bump до 9.x/10.x (где `IFormFile`-handling, OpenAPI 3.1, breaking-changes в `IOperationFilter` и пр.) — **отдельным PR**.

## Test plan
- [x] `dotnet restore` — нет больше предупреждения `NU1603` для Swashbuckle
- [x] `dotnet build src/Dex.sln -c Release` — 0 ошибок
- [x] `dotnet build src/Dex.Audit/Dex.Audit.sln -c Release` — 0 ошибок
- [x] `dotnet build src/Dex.Response.Signing/Dex.ResponseSigning.sln -c Release` — **0 ошибок** (было 6)
- [x] `Dex.ResponseSigning.Tests` — 1/1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)