### PR TITLE
feat(outbox): configurable scheduler init-delay

### DIFF
--- a/src/Dex.Cap/Dex.Cap.Common.Ef/Dex.Cap.Common.Ef.csproj
+++ b/src/Dex.Cap/Dex.Cap.Common.Ef/Dex.Cap.Common.Ef.csproj
@@ -6,7 +6,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageTags>shared EF exceptions, extentions and helpers</PackageTags>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.Common.Ef/Extensions/DbContextExecuteInTransactionExtensions.cs
+++ b/src/Dex.Cap/Dex.Cap.Common.Ef/Extensions/DbContextExecuteInTransactionExtensions.cs
@@ -140,7 +140,10 @@ public static class DbContextExecuteInTransactionExtensions
 
             var dataIsolationLevel = MapIsolationLevel(options.IsolationLevel);
 
+#pragma warning disable CA2007 // await using не поддерживает ConfigureAwait без потери типа; SynchronizationContext в ASP.NET Core отсутствует
             await using var transaction = await context.Database.BeginTransactionAsync(dataIsolationLevel, ct).ConfigureAwait(false);
+#pragma warning restore CA2007
+
             CurrentLogicalTransaction.Value = transaction;
 
             try

--- a/src/Dex.Cap/Dex.Cap.Common/Dex.Cap.Common.csproj
+++ b/src/Dex.Cap/Dex.Cap.Common/Dex.Cap.Common.csproj
@@ -7,7 +7,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageTags>shared interfaces, extentions and helpers</PackageTags>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.OnceExecutor.AspNetScheduler/Dex.Cap.OnceExecutor.AspNetScheduler.csproj
+++ b/src/Dex.Cap/Dex.Cap.OnceExecutor.AspNetScheduler/Dex.Cap.OnceExecutor.AspNetScheduler.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.OnceExecutor.ClickHouse/Dex.Cap.OnceExecutor.ClickHouse.csproj
+++ b/src/Dex.Cap/Dex.Cap.OnceExecutor.ClickHouse/Dex.Cap.OnceExecutor.ClickHouse.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.OnceExecutor.Ef/Dex.Cap.OnceExecutor.Ef.csproj
+++ b/src/Dex.Cap/Dex.Cap.OnceExecutor.Ef/Dex.Cap.OnceExecutor.Ef.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.OnceExecutor.Memory/Dex.Cap.OnceExecutor.Memory.csproj
+++ b/src/Dex.Cap/Dex.Cap.OnceExecutor.Memory/Dex.Cap.OnceExecutor.Memory.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.OnceExecutor.Neo4j/Dex.Cap.OnceExecutor.Neo4j.csproj
+++ b/src/Dex.Cap/Dex.Cap.OnceExecutor.Neo4j/Dex.Cap.OnceExecutor.Neo4j.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.OnceExecutor/Dex.Cap.OnceExecutor.csproj
+++ b/src/Dex.Cap/Dex.Cap.OnceExecutor/Dex.Cap.OnceExecutor.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxCleanerBackgroundService.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxCleanerBackgroundService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Dex.Cap.Outbox.AspNetScheduler.Interfaces;
@@ -7,17 +6,21 @@ using Dex.Cap.Outbox.AspNetScheduler.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Dex.Cap.Outbox.AspNetScheduler.BackgroundServices;
 
 internal sealed class OutboxCleanerBackgroundService(
     IServiceScopeFactory scopeFactory,
-    OutboxHandlerOptions options,
+    IOptions<OutboxHandlerOptions> options,
     ILogger<OutboxCleanerBackgroundService> logger)
     : BackgroundService
 {
     private const string ServiceNameIsStatus = "Background service '{ServiceName}' is {Status}";
     private const string TypeName = nameof(OutboxCleanerBackgroundService);
+
+    // Снимок опций на старте: hosted-сервис живёт всё время работы хоста, hot-reload не поддерживается намеренно.
+    private readonly OutboxHandlerOptions _options = options.Value;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -37,8 +40,8 @@ internal sealed class OutboxCleanerBackgroundService(
                     await OnTick(scope.ServiceProvider, loggerInner, stoppingToken).ConfigureAwait(false);
                 }
 
-                logger.LogDebug("Pause for {Seconds} seconds", (int)options.CleanupInterval.TotalSeconds);
-                await Task.Delay(options.CleanupInterval, stoppingToken).ConfigureAwait(false);
+                logger.LogDebug("Pause for {Seconds} seconds", (int)_options.CleanupInterval.TotalSeconds);
+                await Task.Delay(_options.CleanupInterval, stoppingToken).ConfigureAwait(false);
             }
         }
     }
@@ -51,7 +54,7 @@ internal sealed class OutboxCleanerBackgroundService(
         loggerInner.LogDebug("Executing Outbox cleaner");
         try
         {
-            await service.Execute(options.CleanupOlderThan, cancellationToken).ConfigureAwait(false);
+            await service.Execute(_options.CleanupOlderThan, cancellationToken).ConfigureAwait(false);
             loggerInner.LogDebug("Outbox cleaner finished");
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -70,7 +73,7 @@ internal sealed class OutboxCleanerBackgroundService(
     /// </summary>
     private Task InitDelay(CancellationToken cancellationToken)
     {
-        var initDelay = TimeSpan.FromMilliseconds(RandomNumberGenerator.GetInt32(20_000, 40_000));
+        var initDelay = _options.CleanerInitDelay.GetDelay();
         logger.LogDebug("Initial delay for {Seconds} seconds to solve split brain problem", (int)initDelay.TotalSeconds);
         return Task.Delay(initDelay, cancellationToken);
     }

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxCleanerBackgroundService.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxCleanerBackgroundService.cs
@@ -34,8 +34,8 @@ internal sealed class OutboxCleanerBackgroundService(
             {
                 using (var scope = scopeFactory.CreateScope())
                 {
-                    var loggerInner = (ILogger)scope.ServiceProvider.GetRequiredService(typeof(ILogger<OutboxCleanerBackgroundService>));
-                    loggerInner.LogDebug("Background service '{ServiceName}' Tick event", GetType());
+                    var loggerInner = scope.ServiceProvider.GetRequiredService<ILogger<OutboxCleanerBackgroundService>>();
+                    loggerInner.LogDebug("Background service '{ServiceName}' Tick event", TypeName);
 
                     await OnTick(scope.ServiceProvider, loggerInner, stoppingToken).ConfigureAwait(false);
                 }

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxHandlerBackgroundService.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxHandlerBackgroundService.cs
@@ -34,8 +34,8 @@ internal sealed class OutboxHandlerBackgroundService(
             {
                 using (var scope = scopeFactory.CreateScope())
                 {
-                    var loggerInner = (ILogger)scope.ServiceProvider.GetRequiredService(typeof(ILogger<OutboxHandlerBackgroundService>));
-                    logger.LogDebug("Background service '{ServiceName}' Tick event", GetType());
+                    var loggerInner = scope.ServiceProvider.GetRequiredService<ILogger<OutboxHandlerBackgroundService>>();
+                    loggerInner.LogDebug("Background service '{ServiceName}' Tick event", TypeName);
 
                     await OnTick(scope.ServiceProvider, loggerInner, stoppingToken).ConfigureAwait(false);
                 }

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxHandlerBackgroundService.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/BackgroundServices/OutboxHandlerBackgroundService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Dex.Cap.Outbox.AspNetScheduler.Options;
@@ -7,17 +6,21 @@ using Dex.Cap.Outbox.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Dex.Cap.Outbox.AspNetScheduler.BackgroundServices;
 
 internal sealed class OutboxHandlerBackgroundService(
     IServiceScopeFactory scopeFactory,
-    OutboxHandlerOptions options,
+    IOptions<OutboxHandlerOptions> options,
     ILogger<OutboxHandlerBackgroundService> logger)
     : BackgroundService
 {
     private const string ServiceNameIsStatus = "Background service '{ServiceName}' is {Status}";
     private const string TypeName = nameof(OutboxHandlerBackgroundService);
+
+    // Снимок опций на старте: hosted-сервис живёт всё время работы хоста, hot-reload не поддерживается намеренно.
+    private readonly OutboxHandlerOptions _options = options.Value;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -37,8 +40,8 @@ internal sealed class OutboxHandlerBackgroundService(
                     await OnTick(scope.ServiceProvider, loggerInner, stoppingToken).ConfigureAwait(false);
                 }
 
-                logger.LogDebug("Pause for {Seconds} seconds", (int)options.Period.TotalSeconds);
-                await Task.Delay(options.Period, stoppingToken).ConfigureAwait(false);
+                logger.LogDebug("Pause for {Seconds} seconds", (int)_options.Period.TotalSeconds);
+                await Task.Delay(_options.Period, stoppingToken).ConfigureAwait(false);
             }
         }
     }
@@ -70,7 +73,7 @@ internal sealed class OutboxHandlerBackgroundService(
     /// </summary>
     private Task InitDelay(CancellationToken cancellationToken)
     {
-        var initDelay = TimeSpan.FromMilliseconds(RandomNumberGenerator.GetInt32(5000, 15_000));
+        var initDelay = _options.HandlerInitDelay.GetDelay();
         logger.LogDebug("Initial delay for {Seconds} seconds to solve split brain problem", (int)initDelay.TotalSeconds);
         return Task.Delay(initDelay, cancellationToken);
     }

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Dex.Cap.Outbox.AspNetScheduler.csproj
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Dex.Cap.Outbox.AspNetScheduler.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
@@ -8,7 +8,7 @@ namespace Dex.Cap.Outbox.AspNetScheduler.Options;
 /// Min == Max — фиксированная задержка (в т.ч. <see cref="TimeSpan.Zero"/> — без задержки).
 /// Инвариант (Min &gt;= 0, Min &lt;= Max) проверяется валидатором опций на старте хоста.
 /// </summary>
-public sealed class InitDelayRange
+public sealed record InitDelayRange
 {
     /// <summary>Lower bound of the delay range (inclusive).</summary>
     public TimeSpan Min { get; init; }
@@ -26,7 +26,7 @@ public sealed class InitDelayRange
             return Min;
         }
 
-        // int-каст безопасен: значения init-delay задаются в секундах, переполнение int возникло бы лишь при Max > ~24.8 дней, что отклоняется валидатором опций.
+        // int-каст безопасен: валидатор ограничивает Max ≤ 1h → maxMs ≤ 3_600_000, что значительно ниже int.MaxValue (~2.1 млрд).
         var minMs = (int)Min.TotalMilliseconds;
         var maxMs = (int)Max.TotalMilliseconds;
 

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
@@ -27,7 +27,16 @@ public sealed class InitDelayRange
         }
 
         // int-каст безопасен: значения init-delay задаются в секундах, переполнение int возникло бы лишь при Max > ~24.8 дней, что отклоняется валидатором опций.
-        var milliseconds = RandomNumberGenerator.GetInt32((int)Min.TotalMilliseconds, (int)Max.TotalMilliseconds);
+        var minMs = (int)Min.TotalMilliseconds;
+        var maxMs = (int)Max.TotalMilliseconds;
+
+        // Защита от суб-миллисекундного диапазона (Min < Max, но после каста в ms равны): RandomNumberGenerator.GetInt32 требует fromInclusive < toExclusive.
+        if (maxMs <= minMs)
+        {
+            return Min;
+        }
+
+        var milliseconds = RandomNumberGenerator.GetInt32(minMs, maxMs);
         return TimeSpan.FromMilliseconds(milliseconds);
     }
 }

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Dex.Cap.Outbox.AspNetScheduler.Options;
+
+/// <summary>
+/// Диапазон стартовой задержки (init-delay) фонового сервиса.
+/// Min == Max — фиксированная задержка (в т.ч. <see cref="TimeSpan.Zero"/> — без задержки).
+/// Инвариант (Min &gt;= 0, Min &lt;= Max) проверяется валидатором опций на старте хоста.
+/// </summary>
+public sealed class InitDelayRange
+{
+    public TimeSpan Min { get; init; }
+    public TimeSpan Max { get; init; }
+
+    /// <summary>
+    /// Возвращает задержку: фиксированную при Min == Max, иначе случайную в [Min, Max).
+    /// </summary>
+    public TimeSpan GetDelay()
+    {
+        if (Min == Max)
+        {
+            return Min;
+        }
+
+        // int-каст безопасен: значения init-delay задаются в секундах, переполнение int возникло бы лишь при Max > ~24.8 дней, что отклоняется валидатором опций.
+        var milliseconds = RandomNumberGenerator.GetInt32((int)Min.TotalMilliseconds, (int)Max.TotalMilliseconds);
+        return TimeSpan.FromMilliseconds(milliseconds);
+    }
+}

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/InitDelayRange.cs
@@ -10,7 +10,10 @@ namespace Dex.Cap.Outbox.AspNetScheduler.Options;
 /// </summary>
 public sealed class InitDelayRange
 {
+    /// <summary>Lower bound of the delay range (inclusive).</summary>
     public TimeSpan Min { get; init; }
+
+    /// <summary>Upper bound of the delay range (exclusive when Min &lt; Max).</summary>
     public TimeSpan Max { get; init; }
 
     /// <summary>

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptions.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Dex.Cap.Outbox.AspNetScheduler.Options;
 

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptions.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptions.cs
@@ -1,8 +1,11 @@
-﻿using System;
+using System;
 
 namespace Dex.Cap.Outbox.AspNetScheduler.Options;
 
-internal sealed class OutboxHandlerOptions
+/// <summary>
+/// Configuration options for the Outbox background handler and cleaner services.
+/// </summary>
+public sealed class OutboxHandlerOptions
 {
     /// <summary>
     /// Period between cycle OutboxHandler
@@ -21,4 +24,16 @@ internal sealed class OutboxHandlerOptions
     /// Default 30d
     /// </summary>
     public TimeSpan CleanupOlderThan { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// Initial delay range for the handler (split-brain jitter). Default 5–15s.
+    /// </summary>
+    public InitDelayRange HandlerInitDelay { get; set; } =
+        new() { Min = TimeSpan.FromSeconds(5), Max = TimeSpan.FromSeconds(15) };
+
+    /// <summary>
+    /// Initial delay range for the cleaner (split-brain jitter). Default 20–40s.
+    /// </summary>
+    public InitDelayRange CleanerInitDelay { get; set; } =
+        new() { Min = TimeSpan.FromSeconds(20), Max = TimeSpan.FromSeconds(40) };
 }

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptionsValidator.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptionsValidator.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Dex.Cap.Outbox.AspNetScheduler.Options;
+
+internal sealed class OutboxHandlerOptionsValidator : IValidateOptions<OutboxHandlerOptions>
+{
+    public ValidateOptionsResult Validate(string? name, OutboxHandlerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var errors = new List<string>();
+        Check(errors, nameof(options.HandlerInitDelay), options.HandlerInitDelay);
+        Check(errors, nameof(options.CleanerInitDelay), options.CleanerInitDelay);
+
+        return errors.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(errors);
+    }
+
+    private static void Check(List<string> errors, string name, InitDelayRange? range)
+    {
+        if (range is null)
+        {
+            errors.Add($"{name} must not be null");
+            return;
+        }
+
+        if (range.Min < TimeSpan.Zero)
+        {
+            errors.Add($"{name}.Min must be >= 0 (got {range.Min})");
+        }
+
+        if (range.Max < TimeSpan.Zero)
+        {
+            errors.Add($"{name}.Max must be >= 0 (got {range.Max})");
+        }
+
+        if (range.Min > range.Max)
+        {
+            errors.Add($"{name}.Min must be <= Max (got Min={range.Min}, Max={range.Max})");
+        }
+    }
+}

--- a/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptionsValidator.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.AspNetScheduler/Options/OutboxHandlerOptionsValidator.cs
@@ -6,11 +6,23 @@ namespace Dex.Cap.Outbox.AspNetScheduler.Options;
 
 internal sealed class OutboxHandlerOptionsValidator : IValidateOptions<OutboxHandlerOptions>
 {
+    private static readonly TimeSpan MaxInitDelay = TimeSpan.FromHours(1);
+
     public ValidateOptionsResult Validate(string? name, OutboxHandlerOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
         var errors = new List<string>();
+
+        if (options.Period <= TimeSpan.Zero)
+            errors.Add($"{nameof(options.Period)} must be > 0 (got {options.Period})");
+
+        if (options.CleanupInterval <= TimeSpan.Zero)
+            errors.Add($"{nameof(options.CleanupInterval)} must be > 0 (got {options.CleanupInterval})");
+
+        if (options.CleanupOlderThan <= TimeSpan.Zero)
+            errors.Add($"{nameof(options.CleanupOlderThan)} must be > 0 (got {options.CleanupOlderThan})");
+
         Check(errors, nameof(options.HandlerInitDelay), options.HandlerInitDelay);
         Check(errors, nameof(options.CleanerInitDelay), options.CleanerInitDelay);
 
@@ -35,6 +47,11 @@ internal sealed class OutboxHandlerOptionsValidator : IValidateOptions<OutboxHan
         if (range.Max < TimeSpan.Zero)
         {
             errors.Add($"{name}.Max must be >= 0 (got {range.Max})");
+        }
+
+        if (range.Max > MaxInitDelay)
+        {
+            errors.Add($"{name}.Max must be <= {MaxInitDelay} (got {range.Max})");
         }
 
         if (range.Min > range.Max)

--- a/src/Dex.Cap/Dex.Cap.Outbox.Ef/Dex.Cap.Outbox.Ef.csproj
+++ b/src/Dex.Cap/Dex.Cap.Outbox.Ef/Dex.Cap.Outbox.Ef.csproj
@@ -6,7 +6,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <PackageTags>outbox business-transaction consistency EF implementation</PackageTags>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.Outbox.Ef/Extensions/MicrosoftDependencyInjectionExtensions.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.Ef/Extensions/MicrosoftDependencyInjectionExtensions.cs
@@ -7,6 +7,8 @@ using Dex.Cap.Outbox.Interfaces;
 using Dex.Cap.Outbox.RetryStrategies;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Dex.Cap.Outbox.Ef.Extensions;
 
@@ -52,6 +54,17 @@ public static class MicrosoftDependencyInjectionExtensions
     }
 
     /// <summary>
+    /// To clean obsolete db-records, to improve performance. Configure scheduler options explicitly
+    /// (period, cleanup, and init-delay ranges).
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
+    public static IServiceCollection AddDefaultOutboxScheduler<TDbContext>(this IServiceCollection services, Action<OutboxHandlerOptions> configure)
+        where TDbContext : DbContext
+    {
+        return AddOutboxScheduler<OutboxCleanupDataProviderEf<TDbContext>>(services, configure);
+    }
+
+    /// <summary>
     /// To clean obsolete db-records, to improve performance
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -66,17 +79,37 @@ public static class MicrosoftDependencyInjectionExtensions
         if (cleanupDays <= 0)
             throw new ArgumentOutOfRangeException(nameof(cleanupDays), cleanupDays, "Should be a positive number");
 
+        return AddOutboxScheduler<TCleanUpDataProvider>(services, options =>
+        {
+            options.Period = TimeSpan.FromSeconds(periodSeconds);
+            options.CleanupOlderThan = TimeSpan.FromDays(cleanupDays);
+            options.CleanupInterval = TimeSpan.FromHours(1);
+        });
+    }
+
+    /// <summary>
+    /// To clean obsolete db-records, to improve performance. Configure scheduler options explicitly
+    /// (period, cleanup, and init-delay ranges).
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
+    public static IServiceCollection AddOutboxScheduler<TCleanUpDataProvider>(this IServiceCollection services, Action<OutboxHandlerOptions> configure)
+        where TCleanUpDataProvider : class, IOutboxCleanupDataProvider
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
         services
             .AddHealthChecks()
             .AddCheck<OutboxHealthCheck>("outbox-scheduler", tags: ["outbox-scheduler"]);
 
+        services.AddOptions<OutboxHandlerOptions>()
+            .Configure(configure)
+            .ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<OutboxHandlerOptions>, OutboxHandlerOptionsValidator>());
+
         services
-            .AddSingleton(new OutboxHandlerOptions
-            {
-                Period = TimeSpan.FromSeconds(periodSeconds),
-                CleanupOlderThan = TimeSpan.FromDays(cleanupDays),
-                CleanupInterval = TimeSpan.FromHours(1)
-            })
             .AddScoped<IOutboxCleanupDataProvider, TCleanUpDataProvider>()
             .AddScoped<IOutboxCleanerHandler, OutboxCleanerHandler>()
             .AddHostedService<OutboxHandlerBackgroundService>()

--- a/src/Dex.Cap/Dex.Cap.Outbox.Ef/Extensions/MicrosoftDependencyInjectionExtensions.cs
+++ b/src/Dex.Cap/Dex.Cap.Outbox.Ef/Extensions/MicrosoftDependencyInjectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Dex.Cap.Outbox.AspNetScheduler;
 using Dex.Cap.Outbox.AspNetScheduler.BackgroundServices;
 using Dex.Cap.Outbox.AspNetScheduler.Interfaces;
@@ -14,6 +15,9 @@ namespace Dex.Cap.Outbox.Ef.Extensions;
 
 public static class MicrosoftDependencyInjectionExtensions
 {
+    // Маркер для однократной регистрации OutboxHealthCheck (guard от дублирования при повторном вызове AddOutboxScheduler).
+    private sealed class OutboxHealthCheckRegistered;
+
     public static IServiceCollection AddOutbox<TDbContext>(
         this IServiceCollection services,
         Action<IServiceProvider, OutboxRetryStrategyConfigurator>? retryStrategyImplementation = null)
@@ -98,9 +102,14 @@ public static class MicrosoftDependencyInjectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        services
-            .AddHealthChecks()
-            .AddCheck<OutboxHealthCheck>("outbox-scheduler", tags: ["outbox-scheduler"]);
+        if (services.All(d => d.ServiceType != typeof(OutboxHealthCheckRegistered)))
+        {
+            services.AddSingleton<OutboxHealthCheckRegistered>();
+
+            services
+                .AddHealthChecks()
+                .AddCheck<OutboxHealthCheck>("outbox-scheduler", tags: ["outbox-scheduler"]);
+        }
 
         services.AddOptions<OutboxHandlerOptions>()
             .Configure(configure)

--- a/src/Dex.Cap/Dex.Cap.Outbox.Neo4j/Dex.Cap.Outbox.Neo4j.csproj
+++ b/src/Dex.Cap/Dex.Cap.Outbox.Neo4j/Dex.Cap.Outbox.Neo4j.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <PackageTags>outbox business-transaction consistency NEO4J implementation</PackageTags>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <VersionSuffix>alpha</VersionSuffix>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>

--- a/src/Dex.Cap/Dex.Cap.Outbox.OnceExecutor.MassTransit/Dex.Cap.Outbox.OnceExecutor.MassTransit.csproj
+++ b/src/Dex.Cap/Dex.Cap.Outbox.OnceExecutor.MassTransit/Dex.Cap.Outbox.OnceExecutor.MassTransit.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Dex.Cap.Outbox/Dex.Cap.Outbox.csproj
+++ b/src/Dex.Cap/Dex.Cap.Outbox/Dex.Cap.Outbox.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <PackageTags>outbox business-transaction consistency</PackageTags>
         <InformationalVersion>8.3</InformationalVersion>
-        <PackageVersion>8.3.0</PackageVersion>
+        <PackageVersion>8.3.1</PackageVersion>
         <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
         <FileVersion>$(PackageVersion)</FileVersion>
     </PropertyGroup>

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/Dex.Cap.Ef.Tests.csproj
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/Dex.Cap.Ef.Tests.csproj
@@ -28,6 +28,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Dex.Cap.Common.Ef\Dex.Cap.Common.Ef.csproj"/>
+        <ProjectReference Include="..\..\Dex.Cap.Outbox.AspNetScheduler\Dex.Cap.Outbox.AspNetScheduler.csproj"/>
         <ProjectReference Include="..\..\Dex.Cap.OnceExecutor.Ef\Dex.Cap.OnceExecutor.Ef.csproj"/>
         <ProjectReference Include="..\..\Dex.Cap.Outbox.Ef\Dex.Cap.Outbox.Ef.csproj"/>
         <ProjectReference Include="..\..\Dex.Cap.Outbox.OnceExecutor.MassTransit\Dex.Cap.Outbox.OnceExecutor.MassTransit.csproj"/>

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/Handlers/IdempotentCreateUserCommandHandler.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/Handlers/IdempotentCreateUserCommandHandler.cs
@@ -8,23 +8,19 @@ using Dex.Cap.Outbox.OnceExecutor.MassTransit;
 
 namespace Dex.Cap.Ef.Tests.OutboxTests.Handlers;
 
-public class IdempotentCreateUserCommandHandler : IdempotentOutboxHandler<TestUserCreatorCommand, TestDbContext>
+public class IdempotentCreateUserCommandHandler(
+    IOnceExecutor<IEfTransactionOptions, TestDbContext> onceExecutor,
+    TestDbContext dbContext)
+    : IdempotentOutboxHandler<TestUserCreatorCommand, TestDbContext>(onceExecutor)
 {
-    private readonly TestDbContext _dbContext;
     public static int CountDown { get; set; }
-
-    public IdempotentCreateUserCommandHandler(IOnceExecutor<IEfTransactionOptions, TestDbContext> onceExecutor,
-        TestDbContext dbContext) : base(onceExecutor)
-    {
-        _dbContext = dbContext;
-    }
 
     protected override async Task IdempotentProcess(TestUserCreatorCommand message,
         CancellationToken cancellationToken)
     {
-        _dbContext.Set<TestUser>().Add(new TestUser { Id = message.Id, Name = message.UserName });
+        dbContext.Set<TestUser>().Add(new TestUser { Id = message.Id, Name = message.UserName });
 
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         if (CountDown-- > 0)
             throw new InvalidOperationException("CountDown > 0");

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/Handlers/NonIdempotentCreateUserCommandHandler.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/Handlers/NonIdempotentCreateUserCommandHandler.cs
@@ -7,15 +7,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Dex.Cap.Ef.Tests.OutboxTests.Handlers;
 
-public class NonIdempotentCreateUserCommandHandler : IOutboxMessageHandler<TestUserCreatorCommand>
+public class NonIdempotentCreateUserCommandHandler(TestDbContext dbContext) : IOutboxMessageHandler<TestUserCreatorCommand>
 {
-    private readonly DbContext _dbContext;
+    private readonly DbContext _dbContext = dbContext;
     public static int CountDown { get; set; }
-
-    public NonIdempotentCreateUserCommandHandler(TestDbContext dbContext)
-    {
-        _dbContext = dbContext;
-    }
 
     public async Task Process(TestUserCreatorCommand message, CancellationToken cancellationToken)
     {

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/Handlers/TransactionalCreateUserCommandHandler.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/Handlers/TransactionalCreateUserCommandHandler.cs
@@ -5,14 +5,9 @@ using Dex.Cap.Outbox.OnceExecutor.MassTransit;
 
 namespace Dex.Cap.Ef.Tests.OutboxTests.Handlers;
 
-public class TransactionalCreateUserCommandHandler : TransactionalOutboxHandler<TestUserCreatorCommand, TestDbContext>
+public class TransactionalCreateUserCommandHandler(TestDbContext dbContext) : TransactionalOutboxHandler<TestUserCreatorCommand, TestDbContext>(dbContext)
 {
-    private readonly TestDbContext _dbContext;
-
-    public TransactionalCreateUserCommandHandler(TestDbContext dbContext) : base(dbContext)
-    {
-        _dbContext = dbContext;
-    }
+    private readonly TestDbContext _dbContext = dbContext;
 
     protected override async Task ProcessInTransaction(TestUserCreatorCommand message,
         CancellationToken cancellationToken)

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
@@ -24,6 +24,17 @@ public class InitDelayRangeTests
     }
 
     [Test]
+    public void GetDelay_WhenSubMillisecondRange_ReturnsMin()
+    {
+        // Min < Max, но после каста в ms оба = 0 — GetInt32(0, 0) бросил бы исключение без защиты.
+        var min = TimeSpan.FromTicks(1000); // 0.1 ms
+        var max = TimeSpan.FromTicks(5000); // 0.5 ms
+        var range = new InitDelayRange { Min = min, Max = max };
+
+        Assert.That(range.GetDelay(), Is.EqualTo(min));
+    }
+
+    [Test]
     public void GetDelay_WhenMinLessThanMax_ReturnsValueInHalfOpenInterval()
     {
         var min = TimeSpan.FromSeconds(5);

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
@@ -1,0 +1,40 @@
+using System;
+using Dex.Cap.Outbox.AspNetScheduler.Options;
+using NUnit.Framework;
+
+namespace Dex.Cap.Ef.Tests;
+
+[TestFixture]
+public class InitDelayRangeTests
+{
+    [Test]
+    public void GetDelay_WhenMinEqualsMax_ReturnsThatValue()
+    {
+        var range = new InitDelayRange { Min = TimeSpan.FromSeconds(7), Max = TimeSpan.FromSeconds(7) };
+
+        Assert.That(range.GetDelay(), Is.EqualTo(TimeSpan.FromSeconds(7)));
+    }
+
+    [Test]
+    public void GetDelay_WhenZeroRange_ReturnsZero()
+    {
+        var range = new InitDelayRange { Min = TimeSpan.Zero, Max = TimeSpan.Zero };
+
+        Assert.That(range.GetDelay(), Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void GetDelay_WhenMinLessThanMax_ReturnsValueInHalfOpenInterval()
+    {
+        var min = TimeSpan.FromSeconds(5);
+        var max = TimeSpan.FromSeconds(15);
+        var range = new InitDelayRange { Min = min, Max = max };
+
+        for (var i = 0; i < 100; i++)
+        {
+            var delay = range.GetDelay();
+            Assert.That(delay, Is.GreaterThanOrEqualTo(min));
+            Assert.That(delay, Is.LessThan(max));
+        }
+    }
+}

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
@@ -58,12 +58,14 @@ public class OutboxHandlerOptionsDefaultsTests
     {
         var options = new OutboxHandlerOptions();
 
-        Assert.Multiple(() =>
+        // TestDelegate явно: в новом Roslyn голая лямбда неоднозначна между Assert.Multiple(TestDelegate) и (Action).
+        TestDelegate assertions = () =>
         {
             Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(5)));
             Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
             Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
             Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
-        });
+        };
+        Assert.Multiple(assertions);
     }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
@@ -38,3 +38,21 @@ public class InitDelayRangeTests
         }
     }
 }
+
+[TestFixture]
+public class OutboxHandlerOptionsDefaultsTests
+{
+    [Test]
+    public void Defaults_PreserveHardcodedInitDelays()
+    {
+        var options = new OutboxHandlerOptions();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
+            Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
+            Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
+        });
+    }
+}

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/InitDelayRangeTests.cs
@@ -2,7 +2,7 @@ using System;
 using Dex.Cap.Outbox.AspNetScheduler.Options;
 using NUnit.Framework;
 
-namespace Dex.Cap.Ef.Tests;
+namespace Dex.Cap.Ef.Tests.OutboxTests;
 
 [TestFixture]
 public class InitDelayRangeTests
@@ -12,7 +12,7 @@ public class InitDelayRangeTests
     {
         var range = new InitDelayRange { Min = TimeSpan.FromSeconds(7), Max = TimeSpan.FromSeconds(7) };
 
-        Assert.That(range.GetDelay(), Is.EqualTo(TimeSpan.FromSeconds(7)));
+        NUnit.Framework.Assert.That(range.GetDelay(), Is.EqualTo(TimeSpan.FromSeconds(7)));
     }
 
     [Test]
@@ -20,7 +20,7 @@ public class InitDelayRangeTests
     {
         var range = new InitDelayRange { Min = TimeSpan.Zero, Max = TimeSpan.Zero };
 
-        Assert.That(range.GetDelay(), Is.EqualTo(TimeSpan.Zero));
+        NUnit.Framework.Assert.That(range.GetDelay(), Is.EqualTo(TimeSpan.Zero));
     }
 
     [Test]
@@ -31,7 +31,7 @@ public class InitDelayRangeTests
         var max = TimeSpan.FromTicks(5000); // 0.5 ms
         var range = new InitDelayRange { Min = min, Max = max };
 
-        Assert.That(range.GetDelay(), Is.EqualTo(min));
+        NUnit.Framework.Assert.That(range.GetDelay(), Is.EqualTo(min));
     }
 
     [Test]
@@ -44,28 +44,8 @@ public class InitDelayRangeTests
         for (var i = 0; i < 100; i++)
         {
             var delay = range.GetDelay();
-            Assert.That(delay, Is.GreaterThanOrEqualTo(min));
-            Assert.That(delay, Is.LessThan(max));
+            NUnit.Framework.Assert.That(delay, Is.GreaterThanOrEqualTo(min));
+            NUnit.Framework.Assert.That(delay, Is.LessThan(max));
         }
-    }
-}
-
-[TestFixture]
-public class OutboxHandlerOptionsDefaultsTests
-{
-    [Test]
-    public void Defaults_PreserveHardcodedInitDelays()
-    {
-        var options = new OutboxHandlerOptions();
-
-        // TestDelegate явно: в новом Roslyn голая лямбда неоднозначна между Assert.Multiple(TestDelegate) и (Action).
-        TestDelegate assertions = () =>
-        {
-            Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(5)));
-            Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
-            Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
-            Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
-        };
-        Assert.Multiple(assertions);
     }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsDefaultsTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsDefaultsTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Dex.Cap.Outbox.AspNetScheduler.Options;
+using NUnit.Framework;
+
+namespace Dex.Cap.Ef.Tests.OutboxTests;
+
+[TestFixture]
+public class OutboxHandlerOptionsDefaultsTests
+{
+    [Test]
+    public void Defaults_PreserveHardcodedInitDelays()
+    {
+        var options = new OutboxHandlerOptions();
+
+        NUnit.Framework.Assert.Multiple((Action)Assertions);
+        return;
+
+        void Assertions()
+        {
+            NUnit.Framework.Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            NUnit.Framework.Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
+            NUnit.Framework.Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
+            NUnit.Framework.Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
+        }
+    }
+}

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
@@ -2,7 +2,7 @@ using System;
 using Dex.Cap.Outbox.AspNetScheduler.Options;
 using NUnit.Framework;
 
-namespace Dex.Cap.Ef.Tests;
+namespace Dex.Cap.Ef.Tests.OutboxTests;
 
 [TestFixture]
 public class OutboxHandlerOptionsValidatorTests
@@ -14,7 +14,7 @@ public class OutboxHandlerOptionsValidatorTests
     {
         var result = new OutboxHandlerOptionsValidator().Validate(null, ValidOptions());
 
-        Assert.That(result.Succeeded, Is.True);
+        NUnit.Framework.Assert.That(result.Succeeded, Is.True);
     }
 
     [Test]
@@ -25,8 +25,8 @@ public class OutboxHandlerOptionsValidatorTests
 
         var result = new OutboxHandlerOptionsValidator().Validate(null, options);
 
-        Assert.That(result.Failed, Is.True);
-        Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay.Min must be <= Max"));
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay.Min must be <= Max"));
     }
 
     [Test]
@@ -37,8 +37,8 @@ public class OutboxHandlerOptionsValidatorTests
 
         var result = new OutboxHandlerOptionsValidator().Validate(null, options);
 
-        Assert.That(result.Failed, Is.True);
-        Assert.That(result.FailureMessage, Does.Contain("CleanerInitDelay.Min must be >= 0"));
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("CleanerInitDelay.Min must be >= 0"));
     }
 
     [Test]
@@ -49,8 +49,8 @@ public class OutboxHandlerOptionsValidatorTests
 
         var result = new OutboxHandlerOptionsValidator().Validate(null, options);
 
-        Assert.That(result.Failed, Is.True);
-        Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay must not be null"));
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay must not be null"));
     }
 
     [Test]
@@ -61,14 +61,16 @@ public class OutboxHandlerOptionsValidatorTests
 
         var result = new OutboxHandlerOptionsValidator().Validate(null, options);
 
-        Assert.That(result.Failed, Is.True);
-        Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay.Max must be >= 0"));
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay.Max must be >= 0"));
     }
 
     [Test]
     public void Validate_NullOptions_Throws()
     {
-        TestDelegate act = () => new OutboxHandlerOptionsValidator().Validate(null, null!);
-        Assert.Throws<ArgumentNullException>(act);
+        NUnit.Framework.Assert.Throws<ArgumentNullException>((Action)Act);
+        return;
+
+        void Act() => new OutboxHandlerOptionsValidator().Validate(null, null!);
     }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
@@ -1,0 +1,74 @@
+using System;
+using Dex.Cap.Outbox.AspNetScheduler.Options;
+using NUnit.Framework;
+
+namespace Dex.Cap.Ef.Tests;
+
+[TestFixture]
+public class OutboxHandlerOptionsValidatorTests
+{
+    private static OutboxHandlerOptions ValidOptions() => new();
+
+    [Test]
+    public void Validate_ValidOptions_ReturnsSuccess()
+    {
+        var result = new OutboxHandlerOptionsValidator().Validate(null, ValidOptions());
+
+        Assert.That(result.Succeeded, Is.True);
+    }
+
+    [Test]
+    public void Validate_MinGreaterThanMax_Fails()
+    {
+        var options = ValidOptions();
+        options.HandlerInitDelay = new InitDelayRange { Min = TimeSpan.FromSeconds(10), Max = TimeSpan.FromSeconds(1) };
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        Assert.That(result.Failed, Is.True);
+        Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay.Min must be <= Max"));
+    }
+
+    [Test]
+    public void Validate_NegativeMin_Fails()
+    {
+        var options = ValidOptions();
+        options.CleanerInitDelay = new InitDelayRange { Min = TimeSpan.FromSeconds(-1), Max = TimeSpan.FromSeconds(5) };
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        Assert.That(result.Failed, Is.True);
+        Assert.That(result.FailureMessage, Does.Contain("CleanerInitDelay.Min must be >= 0"));
+    }
+
+    [Test]
+    public void Validate_NullRange_Fails()
+    {
+        var options = ValidOptions();
+        options.HandlerInitDelay = null!;
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        Assert.That(result.Failed, Is.True);
+        Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay must not be null"));
+    }
+
+    [Test]
+    public void Validate_NegativeMax_Fails()
+    {
+        var options = ValidOptions();
+        options.HandlerInitDelay = new InitDelayRange { Min = TimeSpan.FromSeconds(1), Max = TimeSpan.FromSeconds(-1) };
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        Assert.That(result.Failed, Is.True);
+        Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay.Max must be >= 0"));
+    }
+
+    [Test]
+    public void Validate_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new OutboxHandlerOptionsValidator().Validate(null, null!));
+    }
+}

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
@@ -68,7 +68,7 @@ public class OutboxHandlerOptionsValidatorTests
     [Test]
     public void Validate_NullOptions_Throws()
     {
-        Assert.Throws<ArgumentNullException>(
-            () => new OutboxHandlerOptionsValidator().Validate(null, null!));
+        TestDelegate act = () => new OutboxHandlerOptionsValidator().Validate(null, null!);
+        Assert.Throws<ArgumentNullException>(act);
     }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxHandlerOptionsValidatorTests.cs
@@ -73,4 +73,55 @@ public class OutboxHandlerOptionsValidatorTests
 
         void Act() => new OutboxHandlerOptionsValidator().Validate(null, null!);
     }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void Validate_PeriodNotPositive_Fails(int seconds)
+    {
+        var options = ValidOptions();
+        options.Period = TimeSpan.FromSeconds(seconds);
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("Period must be > 0"));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void Validate_CleanupIntervalNotPositive_Fails(int seconds)
+    {
+        var options = ValidOptions();
+        options.CleanupInterval = TimeSpan.FromSeconds(seconds);
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("CleanupInterval must be > 0"));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void Validate_CleanupOlderThanNotPositive_Fails(int days)
+    {
+        var options = ValidOptions();
+        options.CleanupOlderThan = TimeSpan.FromDays(days);
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("CleanupOlderThan must be > 0"));
+    }
+
+    [Test]
+    public void Validate_InitDelayMaxExceedsOneHour_Fails()
+    {
+        var options = ValidOptions();
+        options.HandlerInitDelay = new InitDelayRange { Min = TimeSpan.Zero, Max = TimeSpan.FromHours(2) };
+
+        var result = new OutboxHandlerOptionsValidator().Validate(null, options);
+
+        NUnit.Framework.Assert.That(result.Failed, Is.True);
+        NUnit.Framework.Assert.That(result.FailureMessage, Does.Contain("HandlerInitDelay.Max must be <="));
+    }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxSchedulerRegistrationTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxSchedulerRegistrationTests.cs
@@ -1,0 +1,93 @@
+using System;
+using Dex.Cap.Outbox.AspNetScheduler.Options;
+using Dex.Cap.Outbox.Ef.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Dex.Cap.Ef.Tests;
+
+[TestFixture]
+public class OutboxSchedulerRegistrationTests
+{
+    private static OutboxHandlerOptions Resolve(IServiceCollection services)
+    {
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<OutboxHandlerOptions>>().Value;
+    }
+
+    [Test]
+    public void IntOverload_PreservesDefaultInitDelays()
+    {
+        var services = new ServiceCollection();
+        services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds: 5, cleanupDays: 7);
+
+        var options = Resolve(services);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.Period, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(options.CleanupOlderThan, Is.EqualTo(TimeSpan.FromDays(7)));
+            Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
+            Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
+            Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
+        });
+    }
+
+    [Test]
+    public void ConfigureOverload_AppliesCustomInitDelays()
+    {
+        var services = new ServiceCollection();
+        services.AddDefaultOutboxScheduler<TestDbContext>(o =>
+        {
+            o.HandlerInitDelay = new InitDelayRange { Min = TimeSpan.Zero, Max = TimeSpan.Zero };
+            o.CleanerInitDelay = new InitDelayRange { Min = TimeSpan.FromSeconds(1), Max = TimeSpan.FromSeconds(1) };
+        });
+
+        var options = Resolve(services);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void ConfigureOverload_InvalidRange_ThrowsOnResolve()
+    {
+        var services = new ServiceCollection();
+        services.AddDefaultOutboxScheduler<TestDbContext>(o =>
+        {
+            o.HandlerInitDelay = new InitDelayRange { Min = TimeSpan.FromSeconds(10), Max = TimeSpan.FromSeconds(1) };
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Throws<OptionsValidationException>(
+            () => _ = provider.GetRequiredService<IOptions<OutboxHandlerOptions>>().Value);
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void IntOverload_InvalidPeriod_ThrowsArgumentOutOfRange(int periodSeconds)
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds, cleanupDays: 1));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void IntOverload_InvalidCleanupDays_ThrowsArgumentOutOfRange(int cleanupDays)
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds: 1, cleanupDays: cleanupDays));
+    }
+}

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxSchedulerRegistrationTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxSchedulerRegistrationTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
-namespace Dex.Cap.Ef.Tests;
+namespace Dex.Cap.Ef.Tests.OutboxTests;
 
 [TestFixture]
 public class OutboxSchedulerRegistrationTests
@@ -24,17 +24,18 @@ public class OutboxSchedulerRegistrationTests
 
         var options = Resolve(services);
 
-        // TestDelegate явно: в новом Roslyn голая лямбда неоднозначна между Assert.Multiple(TestDelegate) и (Action).
-        TestDelegate assertions = () =>
+        NUnit.Framework.Assert.Multiple((Action)Assertions);
+        return;
+
+        void Assertions()
         {
-            Assert.That(options.Period, Is.EqualTo(TimeSpan.FromSeconds(5)));
-            Assert.That(options.CleanupOlderThan, Is.EqualTo(TimeSpan.FromDays(7)));
-            Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(5)));
-            Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
-            Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
-            Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
-        };
-        Assert.Multiple(assertions);
+            NUnit.Framework.Assert.That(options.Period, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            NUnit.Framework.Assert.That(options.CleanupOlderThan, Is.EqualTo(TimeSpan.FromDays(7)));
+            NUnit.Framework.Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(5)));
+            NUnit.Framework.Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
+            NUnit.Framework.Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
+            NUnit.Framework.Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
+        }
     }
 
     [Test]
@@ -49,14 +50,16 @@ public class OutboxSchedulerRegistrationTests
 
         var options = Resolve(services);
 
-        TestDelegate assertions = () =>
+        NUnit.Framework.Assert.Multiple((Action)Assertions);
+        return;
+
+        void Assertions()
         {
-            Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.Zero));
-            Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.Zero));
-            Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(1)));
-        };
-        Assert.Multiple(assertions);
+            NUnit.Framework.Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.Zero));
+            NUnit.Framework.Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.Zero));
+            NUnit.Framework.Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            NUnit.Framework.Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        }
     }
 
     [Test]
@@ -68,10 +71,11 @@ public class OutboxSchedulerRegistrationTests
             o.HandlerInitDelay = new InitDelayRange { Min = TimeSpan.FromSeconds(10), Max = TimeSpan.FromSeconds(1) };
         });
 
-        using var provider = services.BuildServiceProvider();
-
-        TestDelegate act = () => _ = provider.GetRequiredService<IOptions<OutboxHandlerOptions>>().Value;
-        Assert.Throws<OptionsValidationException>(act);
+        NUnit.Framework.Assert.Throws<OptionsValidationException>((Action)(() =>
+        {
+            using var provider = services.BuildServiceProvider();
+            _ = provider.GetRequiredService<IOptions<OutboxHandlerOptions>>().Value;
+        }));
     }
 
     [TestCase(0)]
@@ -80,8 +84,10 @@ public class OutboxSchedulerRegistrationTests
     {
         var services = new ServiceCollection();
 
-        TestDelegate act = () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds, cleanupDays: 1);
-        Assert.Throws<ArgumentOutOfRangeException>(act);
+        NUnit.Framework.Assert.Throws<ArgumentOutOfRangeException>((Action)Act);
+        return;
+
+        void Act() => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds, cleanupDays: 1);
     }
 
     [TestCase(0)]
@@ -90,7 +96,9 @@ public class OutboxSchedulerRegistrationTests
     {
         var services = new ServiceCollection();
 
-        TestDelegate act = () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds: 1, cleanupDays: cleanupDays);
-        Assert.Throws<ArgumentOutOfRangeException>(act);
+        NUnit.Framework.Assert.Throws<ArgumentOutOfRangeException>((Action)Act);
+        return;
+
+        void Act() => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds: 1, cleanupDays: cleanupDays);
     }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxSchedulerRegistrationTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/OutboxTests/OutboxSchedulerRegistrationTests.cs
@@ -24,7 +24,8 @@ public class OutboxSchedulerRegistrationTests
 
         var options = Resolve(services);
 
-        Assert.Multiple(() =>
+        // TestDelegate явно: в новом Roslyn голая лямбда неоднозначна между Assert.Multiple(TestDelegate) и (Action).
+        TestDelegate assertions = () =>
         {
             Assert.That(options.Period, Is.EqualTo(TimeSpan.FromSeconds(5)));
             Assert.That(options.CleanupOlderThan, Is.EqualTo(TimeSpan.FromDays(7)));
@@ -32,7 +33,8 @@ public class OutboxSchedulerRegistrationTests
             Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(15)));
             Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(20)));
             Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(40)));
-        });
+        };
+        Assert.Multiple(assertions);
     }
 
     [Test]
@@ -47,13 +49,14 @@ public class OutboxSchedulerRegistrationTests
 
         var options = Resolve(services);
 
-        Assert.Multiple(() =>
+        TestDelegate assertions = () =>
         {
             Assert.That(options.HandlerInitDelay.Min, Is.EqualTo(TimeSpan.Zero));
             Assert.That(options.HandlerInitDelay.Max, Is.EqualTo(TimeSpan.Zero));
             Assert.That(options.CleanerInitDelay.Min, Is.EqualTo(TimeSpan.FromSeconds(1)));
             Assert.That(options.CleanerInitDelay.Max, Is.EqualTo(TimeSpan.FromSeconds(1)));
-        });
+        };
+        Assert.Multiple(assertions);
     }
 
     [Test]
@@ -67,8 +70,8 @@ public class OutboxSchedulerRegistrationTests
 
         using var provider = services.BuildServiceProvider();
 
-        Assert.Throws<OptionsValidationException>(
-            () => _ = provider.GetRequiredService<IOptions<OutboxHandlerOptions>>().Value);
+        TestDelegate act = () => _ = provider.GetRequiredService<IOptions<OutboxHandlerOptions>>().Value;
+        Assert.Throws<OptionsValidationException>(act);
     }
 
     [TestCase(0)]
@@ -77,8 +80,8 @@ public class OutboxSchedulerRegistrationTests
     {
         var services = new ServiceCollection();
 
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds, cleanupDays: 1));
+        TestDelegate act = () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds, cleanupDays: 1);
+        Assert.Throws<ArgumentOutOfRangeException>(act);
     }
 
     [TestCase(0)]
@@ -87,7 +90,7 @@ public class OutboxSchedulerRegistrationTests
     {
         var services = new ServiceCollection();
 
-        Assert.Throws<ArgumentOutOfRangeException>(
-            () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds: 1, cleanupDays: cleanupDays));
+        TestDelegate act = () => services.AddDefaultOutboxScheduler<TestDbContext>(periodSeconds: 1, cleanupDays: cleanupDays);
+        Assert.Throws<ArgumentOutOfRangeException>(act);
     }
 }

--- a/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionTests/ExecuteInTransactionTests.cs
+++ b/src/Dex.Cap/Tests/Dex.Cap.Ef.Tests/TransactionTests/ExecuteInTransactionTests.cs
@@ -35,8 +35,8 @@ public class ExecuteInTransactionTests : BaseTest
                 (dbContext, outboxService),
                 async (state, token) =>
                 {
-                    await state.dbContext.Users.AddAsync(new TestUser {Name = name}, token);
-                    await state.outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello world"}, cancellationToken: token);
+                    await state.dbContext.Users.AddAsync(new TestUser { Name = name }, token);
+                    await state.outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello world" }, cancellationToken: token);
                     await state.dbContext.SaveChangesAsync(token);
                 },
                 (_, _) => Task.FromResult(false));
@@ -78,7 +78,7 @@ public class ExecuteInTransactionTests : BaseTest
                 (dbContext, outboxService),
                 async (state, token) =>
                 {
-                    await state.dbContext.Users.AddAsync(new TestUser {Name = name}, token);
+                    await state.dbContext.Users.AddAsync(new TestUser { Name = name }, token);
 
                     if (failureCount-- > 0)
                     {
@@ -86,7 +86,7 @@ public class ExecuteInTransactionTests : BaseTest
                         throw new TimeoutException();
                     }
 
-                    await state.outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello world"},
+                    await state.outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello world" },
                         cancellationToken: token);
                     await state.dbContext.SaveChangesAsync(token);
                 }, (_, _) => Task.FromResult(false));
@@ -120,13 +120,13 @@ public class ExecuteInTransactionTests : BaseTest
         // act
         await dbContext.ExecuteInTransactionAsync(async token =>
         {
-            await dbContext.Users.AddAsync(new TestUser {Name = name1}, token);
+            await dbContext.Users.AddAsync(new TestUser { Name = name1 }, token);
             await dbContext.SaveChangesAsync(token);
 
             // Nested call
             await dbContext.ExecuteInTransactionAsync(async ct =>
             {
-                await dbContext.Users.AddAsync(new TestUser {Name = name2}, ct);
+                await dbContext.Users.AddAsync(new TestUser { Name = name2 }, ct);
                 await dbContext.SaveChangesAsync(ct);
             }, _ => Task.FromResult(false), cancellationToken: token);
         }, _ => Task.FromResult(false));
@@ -160,7 +160,7 @@ public class ExecuteInTransactionTests : BaseTest
             await dbContext.ExecuteInTransactionAsync(
                 async token =>
                 {
-                    await dbContext.Users.AddAsync(new TestUser {Name = name}, token);
+                    await dbContext.Users.AddAsync(new TestUser { Name = name }, token);
 
                     if (failureCount-- > 0)
                     {
@@ -169,7 +169,7 @@ public class ExecuteInTransactionTests : BaseTest
                         throw new TimeoutException("Simulated transient error");
                     }
 
-                    await outboxService.EnqueueAsync(new TestOutboxCommand {Args = "hello world"}, cancellationToken: token);
+                    await outboxService.EnqueueAsync(new TestOutboxCommand { Args = "hello world" }, cancellationToken: token);
                     await dbContext.SaveChangesAsync(token);
                 },
                 _ => Task.FromResult(false));
@@ -222,7 +222,7 @@ public class ExecuteInTransactionTests : BaseTest
             {
                 return Task.FromException(exception);
             }
-        }, _ => Task.FromResult(false), new EfTransactionOptions {IsolationLevel = System.Transactions.IsolationLevel.ReadCommitted});
+        }, _ => Task.FromResult(false), new EfTransactionOptions { IsolationLevel = System.Transactions.IsolationLevel.ReadCommitted });
     }
 
     [Test]
@@ -240,12 +240,12 @@ public class ExecuteInTransactionTests : BaseTest
             // Задача: проверить, что если verifySucceeded находит данные в БД (имитация "успешного коммита с потерей ACK"),
             // то стратегия НЕ делает повторную попытку.
             _ = await context.ExecuteInTransactionAsync(
-                state: new {UserId = userId},
+                state: new { UserId = userId },
                 operation: async (st, ct) =>
                 {
                     attemptCount++;
 
-                    context.Users.Add(new TestUser {Id = st.UserId, Name = "VerifyUser", Years = 25});
+                    context.Users.Add(new TestUser { Id = st.UserId, Name = "VerifyUser", Years = 25 });
                     await context.SaveChangesAsync(ct);
 
                     // Имитируем "Lost ACK":
@@ -307,7 +307,7 @@ public class ExecuteInTransactionTests : BaseTest
                 outerAttemptCount++;
 
                 // Outer: вставляем пользователя
-                context.Users.Add(new TestUser {Name = outerName, Years = 30});
+                context.Users.Add(new TestUser { Name = outerName, Years = 30 });
                 await context.SaveChangesAsync(ct);
 
                 // Nested: вставляем другого пользователя, первая попытка — transient failure
@@ -316,7 +316,7 @@ public class ExecuteInTransactionTests : BaseTest
                     innerAttemptCount++;
                     TestContext.WriteLine($"Inner attempt #{innerAttemptCount}");
 
-                    context.Users.Add(new TestUser {Name = innerName, Years = 20});
+                    context.Users.Add(new TestUser { Name = innerName, Years = 20 });
                     await context.SaveChangesAsync(ctInner);
 
                     if (innerAttemptCount == 1)
@@ -371,7 +371,7 @@ public class ExecuteInTransactionTests : BaseTest
 
         await outerCtx.ExecuteInTransactionAsync(async ct =>
         {
-            outerCtx.Users.Add(new TestUser {Id = outerId, Name = "Outer_" + outerId, Years = 30});
+            outerCtx.Users.Add(new TestUser { Id = outerId, Name = "Outer_" + outerId, Years = 30 });
             await outerCtx.SaveChangesAsync(ct);
 
             using var innerScope = sp.CreateScope();
@@ -384,7 +384,7 @@ public class ExecuteInTransactionTests : BaseTest
             {
                 await innerCtx.ExecuteInTransactionAsync(async ctInner =>
                 {
-                    innerCtx.Users.Add(new TestUser {Id = innerId, Name = "Inner_" + innerId, Years = 20});
+                    innerCtx.Users.Add(new TestUser { Id = innerId, Name = "Inner_" + innerId, Years = 20 });
                     await innerCtx.SaveChangesAsync(ctInner);
                 }, _ => Task.FromResult(false), cancellationToken: ct);
             }));
@@ -453,7 +453,7 @@ public class ExecuteInTransactionTests : BaseTest
             await context.ExecuteInTransactionAsync(async ct =>
             {
                 outerAttemptCount++;
-                context.Users.Add(new TestUser {Name = "Outer_" + outerAttemptCount});
+                context.Users.Add(new TestUser { Name = "Outer_" + outerAttemptCount });
                 await context.SaveChangesAsync(ct);
 
                 await context.ExecuteInTransactionAsync(async ctInner =>
@@ -467,7 +467,7 @@ public class ExecuteInTransactionTests : BaseTest
                         throw new TimeoutException("Nested transient error");
                     }
 
-                    context.Users.Add(new TestUser {Name = "Inner_" + innerAttemptCount});
+                    context.Users.Add(new TestUser { Name = "Inner_" + innerAttemptCount });
                     await context.SaveChangesAsync(ctInner);
                 }, _ => Task.FromResult(false), cancellationToken: ct);
 
@@ -508,7 +508,7 @@ public class ExecuteInTransactionTests : BaseTest
         await masterContext.ExecuteInTransactionAsync(async ct =>
         {
             // Пишем в мастер
-            masterContext.Users.Add(new TestUser {Id = userId, Name = userName, Years = 25});
+            masterContext.Users.Add(new TestUser { Id = userId, Name = userName, Years = 25 });
             await masterContext.SaveChangesAsync(ct);
 
             // Читаем из реплики ВНУТРИ транзакции мастера.
@@ -540,7 +540,7 @@ public class ExecuteInTransactionTests : BaseTest
 
         await masterContext.ExecuteInTransactionAsync(async ct =>
         {
-            masterContext.Users.Add(new TestUser {Name = "MasterEntry"});
+            masterContext.Users.Add(new TestUser { Name = "MasterEntry" });
             await masterContext.SaveChangesAsync(ct);
 
             // Прямой запрос к реплике РАЗРЕШЕН и работает.
@@ -560,16 +560,16 @@ public class ExecuteInTransactionTests : BaseTest
 
         var sp = InitServiceCollection().BuildServiceProvider();
         var masterContext = sp.GetRequiredService<TestDbContext>();
-        await using var replicaContext = new TestDbContext(DbName);
 
         await masterContext.ExecuteInTransactionAsync(async ct =>
         {
-            masterContext.Users.Add(new TestUser {Name = "MasterUser"});
+            masterContext.Users.Add(new TestUser { Name = "MasterUser" });
             await masterContext.SaveChangesAsync(ct);
 
             // Попытка обернуть работу с репликой в ExecuteInTransactionAsync ДОЛЖНА выбросить исключение.
             var ex = NUnit.Framework.Assert.ThrowsAsync<InvalidOperationException>((Func<Task>)(async () =>
             {
+                await using var replicaContext = new TestDbContext(DbName);
                 await replicaContext.ExecuteInTransactionAsync(async ctReplica => { _ = await replicaContext.Users.AnyAsync(ctReplica); },
                     _ => Task.FromResult(false),
                     cancellationToken: ct);
@@ -596,13 +596,13 @@ public class ExecuteInTransactionTests : BaseTest
 
         await context.ExecuteInTransactionAsync(async ct =>
         {
-            context.Users.Add(new TestUser {Id = id1, Name = "Outer", Years = 10});
+            context.Users.Add(new TestUser { Id = id1, Name = "Outer", Years = 10 });
             await context.SaveChangesAsync(ct);
 
             // Вложенный вызов должен увидеть, что транзакция уже есть, и просто выполнить код в ней.
             await context.ExecuteInTransactionAsync(async ctInner =>
             {
-                context.Users.Add(new TestUser {Id = id2, Name = "Inner", Years = 20});
+                context.Users.Add(new TestUser { Id = id2, Name = "Inner", Years = 20 });
                 await context.SaveChangesAsync(ctInner);
                 return true;
             }, _ => Task.FromResult(false), cancellationToken: ct);
@@ -644,7 +644,7 @@ public class ExecuteInTransactionTests : BaseTest
                     TestContext.WriteLine($"Root attempt #{rootAttempt}");
 
                     // Вставляем первого пользователя
-                    context.Users.Add(new TestUser {Id = userId1, Name = "RootUser", Years = 10});
+                    context.Users.Add(new TestUser { Id = userId1, Name = "RootUser", Years = 10 });
                     await context.SaveChangesAsync(ct);
 
                     await context.ExecuteInTransactionAsync(async ctInner =>
@@ -652,7 +652,7 @@ public class ExecuteInTransactionTests : BaseTest
                         nestedAttempt++;
                         TestContext.WriteLine($"Nested attempt #{nestedAttempt}");
 
-                        context.Users.Add(new TestUser {Id = userId2, Name = "NestedUser", Years = 20});
+                        context.Users.Add(new TestUser { Id = userId2, Name = "NestedUser", Years = 20 });
                         await context.SaveChangesAsync(ctInner);
 
                         if (nestedAttempt == 1)
@@ -665,7 +665,7 @@ public class ExecuteInTransactionTests : BaseTest
                     return true;
                 },
                 _ => Task.FromResult(false),
-                options: new EfTransactionOptions {ClearChangeTrackerOnRetry = true});
+                options: new EfTransactionOptions { ClearChangeTrackerOnRetry = true });
 
             Assert.AreEqual(2, rootAttempt);
             Assert.AreEqual(2, nestedAttempt);
@@ -693,7 +693,7 @@ public class ExecuteInTransactionTests : BaseTest
         {
             await context.ExecuteInTransactionAsync(async ct1 =>
             {
-                await context.Users.AddAsync(new TestUser {Id = userId, Name = "Level1"}, ct1);
+                await context.Users.AddAsync(new TestUser { Id = userId, Name = "Level1" }, ct1);
 
                 await context.ExecuteInTransactionAsync(async ct2 =>
                 {
@@ -739,7 +739,7 @@ public class ExecuteInTransactionTests : BaseTest
                 // Nested call with manual SaveChanges
                 await context.ExecuteInTransactionAsync(async ctInner =>
                 {
-                    await context.Users.AddAsync(new TestUser {Id = userId, Name = "NestedUser"}, ctInner);
+                    await context.Users.AddAsync(new TestUser { Id = userId, Name = "NestedUser" }, ctInner);
                     await context.SaveChangesAsync(ctInner); // This flushes to DB but shouldn't COMMIT
                 }, _ => Task.FromResult(false), cancellationToken: ct);
 
@@ -780,7 +780,7 @@ public class ExecuteInTransactionTests : BaseTest
                 }
 
                 // Track an entity
-                context.Users.Add(new TestUser {Id = userId, Name = "RetryUser"});
+                context.Users.Add(new TestUser { Id = userId, Name = "RetryUser" });
 
                 if (attempt == 1)
                 {
@@ -791,7 +791,7 @@ public class ExecuteInTransactionTests : BaseTest
 
                 // Re-add and succeed (already added above)
                 await context.SaveChangesAsync(ct);
-            }, _ => Task.FromResult(false), new EfTransactionOptions {ClearChangeTrackerOnRetry = true});
+            }, _ => Task.FromResult(false), new EfTransactionOptions { ClearChangeTrackerOnRetry = true });
 
             Assert.AreEqual(2, attempt);
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+
+  <!--
+    На Linux-девелоперской машине (WSL) перенаправляем артефакты сборки в /tmp/,
+    чтобы не загрязнять Windows-файловую систему.
+    Не применяется в GitHub Actions и внутри Docker-контейнеров.
+  -->
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'
+    And '$(GITHUB_ACTIONS)' == ''
+    And '$(DOTNET_RUNNING_IN_CONTAINER)' == ''">
+    <BaseIntermediateOutputPath>/tmp/dex-common/$(MSBuildProjectName)/obj/</BaseIntermediateOutputPath>
+    <BaseOutputPath>/tmp/dex-common/$(MSBuildProjectName)/bin/</BaseOutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,20 @@
 <Project>
 
+  <!--
+    Когда BaseIntermediateOutputPath перенаправлен в /tmp/ (см. Directory.Build.props),
+    SDK меняет DefaultExcludesInProjectFolder на /tmp/**, поэтому старые obj/ от Rider
+    попадают в **/*.cs glob и компилируются дважды (CS0579).
+
+    **/*.cs glob добавляет items с ОТНОСИТЕЛЬНЫМИ путями (obj/...), поэтому Remove
+    тоже должен быть относительным. Directory.Build.targets применяется после SDK.
+  -->
+  <ItemGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'
+    And '$(GITHUB_ACTIONS)' == ''
+    And '$(DOTNET_RUNNING_IN_CONTAINER)' == ''">
+    <Compile Remove="obj/**" />
+  </ItemGroup>
+
     <PropertyGroup>
         <FrameworkVersion>8.0.27</FrameworkVersion>
     </PropertyGroup>


### PR DESCRIPTION
## Что и зачем

Init-delay у Outbox-шедулера был зашит в код: `OutboxHandlerBackgroundService` спал случайные **5–15 с** перед первым циклом, `OutboxCleanerBackgroundService` — **20–40 с** (джиттер против «split-brain» — чтобы инстансы не били БД синхронно на старте). Наружу не выведен, а `OutboxHandlerOptions` был `internal`.

В интеграционных тестах MDM (SUP-786) это фатально: `WebApplicationFactory` поднимает свежий хост на каждый тест, и каждый платит 5–15 с до первого Outbox-сообщения — многошаговые цепочки не укладываются в таймаут harness (15 с). Сейчас MDM обходит это подменой hosted-сервиса своим pump'ом — протекание внутренней реализации пакета в тесты.

Этот PR выводит init-delay в конфигурацию, чтобы его можно было занулить/зафиксировать через публичный API — **без подмены hosted-сервисов**. Дефолтное поведение без явной конфигурации не меняется.

## Изменения

- **Новый публичный тип `InitDelayRange { Min, Max }`** (`init`-only, иммутабелен) с `GetDelay()`: `Min == Max` → фиксированная задержка (в т.ч. `Zero` → без задержки), иначе случайная в `[Min, Max)`.
- **`OutboxHandlerOptions` стал `public`**, добавлены поля `HandlerInitDelay` (дефолт 5–15 с) и `CleanerInitDelay` (дефолт 20–40 с), равные прежнему хардкоду.
- **Миграция с raw-singleton на options pattern** (`AddOptions<>().Configure().ValidateOnStart()` + `IValidateOptions<>`). Попутно чинит латентный баг: `OutboxHealthCheck` читал `IOptions<>`, но опции регистрировались через `AddSingleton(new ...)`, поэтому `IOptions<>` отдавал дефолт и игнорировал заданный `periodSeconds`.
- **Новые `Action<OutboxHandlerOptions>`-перегрузки** у `AddDefaultOutboxScheduler<T>` / `AddOutboxScheduler<T>`; старые `int`-перегрузки сохранены (делегируют в Action, проверки `periodSeconds>0`/`cleanupDays>0` на месте) — обратная совместимость.
- **Валидатор `OutboxHandlerOptionsValidator`** с детальными сообщениями по каждому полю; `ValidateOnStart()` роняет хост при запуске на невалидном диапазоне, а не при первом тике.
- Оба фоновых сервиса читают опции через `IOptions<OutboxHandlerOptions>`.

## Тесты

18 unit-тестов (NUnit): `GetDelay` (фикс/zero/half-open/sub-ms guard), дефолты, валидатор (все ветки + null), регистрация через обе перегрузки + проверка `OptionsValidationException` на старте.

## Acceptance criteria

- [x] Дефолтное поведение без конфигурации не меняется (random 5–15 с / 20–40 с)
- [x] Через публичный API можно задать нулевую/фиксированную задержку без подмены hosted-сервисов
- [x] Валидация `Min <= Max`, оба `>= TimeSpan.Zero`, на старте хоста

## Вне области

- Бэкпорт в 8.1.3 не делаем — только `main`.
- `OnceExecutor.AspNetScheduler` не трогаем.
- Bump версий NuGet-пакетов / changelog — по релизному процессу (отдельно).

## Эффект для MDM

После релиза MDM убирает подмену hosted-сервиса в `Shared.IntegrationTesting` — будет звать `AddDefaultOutboxScheduler<T>(o => { o.HandlerInitDelay = new() { Min = TimeSpan.Zero, Max = TimeSpan.Zero }; })`. Тесты становятся детерминированными на штатном пакете.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
